### PR TITLE
chore: D1 마이그레이션 + typecheck/test/CI 기반 구축 (#7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24 # node:sqlite (used by tests) requires Node >= 22.5
+          cache: npm
+      - run: npm ci
+      - run: npm run typecheck
+      - run: npm test
+      - run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@ dist
 .DS_Store
 CLAUDE.local.md
 graphify-out/
+.codex/
+AGENTS.md
+CONTEXT.md
+tmp/
 
 # wrangler files
 .wrangler

--- a/README.md
+++ b/README.md
@@ -12,6 +12,21 @@ npm install
 npm run dev
 ```
 
+## 로컬 DB (D1)
+빈 로컬 D1를 마이그레이션만으로 구성하고 개발용 seed를 넣는다:
+```bash
+npm run db:migrate:local   # migrations/ 적용 → 스키마 재현
+npm run db:seed:local      # migrations/seed-dev.sql (최소 개발 데이터)
+```
+
+## 검증
+```bash
+npm run typecheck   # 클라이언트 + Worker 타입 체크
+npm test            # vitest (Worker API 통합 + 클라이언트 단위)
+npm run build
+```
+> 테스트는 Node 내장 `node:sqlite`(Node ≥ 22.5)로 마이그레이션을 인메모리 D1에 적용해 실행한다. PR마다 GitHub Actions(`.github/workflows/ci.yml`)가 install → typecheck → test → build를 수행한다.
+
 ## 빌드
 ```bash
 npm run build   # → dist/ 생성

--- a/migrations/0001_init.sql
+++ b/migrations/0001_init.sql
@@ -1,0 +1,89 @@
+-- Reproduces the production D1 schema for gbc-seoko-db.
+-- Derived from worker/app.ts queries (events, circles, participations, links,
+-- tweet_infos, ips, circle_ips, verification_log).
+
+CREATE TABLE IF NOT EXISTS events (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  slug        TEXT NOT NULL UNIQUE,
+  title       TEXT NOT NULL,
+  alias       TEXT,
+  fare_id     INTEGER,
+  date_label  TEXT,
+  start_date  TEXT,
+  end_date    TEXT,
+  venue       TEXT,
+  map_url     TEXT,
+  status      TEXT NOT NULL DEFAULT 'active'
+);
+
+CREATE TABLE IF NOT EXISTS circles (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  slug        TEXT NOT NULL UNIQUE,
+  name        TEXT NOT NULL,
+  created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS participations (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  circle_id   INTEGER NOT NULL REFERENCES circles(id) ON DELETE CASCADE,
+  event_id    INTEGER NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+  genre_label TEXT,
+  genre_tags  TEXT,                      -- JSON array of strings
+  booth       TEXT,
+  day         TEXT,
+  booth_url   TEXT,
+  highlight   INTEGER NOT NULL DEFAULT 0,
+  badge       TEXT,
+  note        TEXT,
+  status      TEXT NOT NULL DEFAULT 'confirmed',
+  created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE (circle_id, event_id)
+);
+CREATE INDEX IF NOT EXISTS idx_participations_event ON participations(event_id);
+CREATE INDEX IF NOT EXISTS idx_participations_circle ON participations(circle_id);
+
+CREATE TABLE IF NOT EXISTS links (
+  id               INTEGER PRIMARY KEY AUTOINCREMENT,
+  participation_id INTEGER NOT NULL REFERENCES participations(id) ON DELETE CASCADE,
+  kind             TEXT NOT NULL DEFAULT 'other',
+  label            TEXT NOT NULL,
+  url              TEXT NOT NULL,
+  sort_order       INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_links_participation ON links(participation_id);
+
+CREATE TABLE IF NOT EXISTS tweet_infos (
+  participation_id INTEGER PRIMARY KEY REFERENCES participations(id) ON DELETE CASCADE,
+  url              TEXT NOT NULL,
+  og_title         TEXT,
+  og_description   TEXT,
+  og_image         TEXT,
+  og_site_name     TEXT
+);
+
+CREATE TABLE IF NOT EXISTS ips (
+  id   INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL UNIQUE
+);
+
+CREATE TABLE IF NOT EXISTS circle_ips (
+  circle_id INTEGER NOT NULL REFERENCES circles(id) ON DELETE CASCADE,
+  ip_id     INTEGER NOT NULL REFERENCES ips(id) ON DELETE CASCADE,
+  PRIMARY KEY (circle_id, ip_id)
+);
+CREATE INDEX IF NOT EXISTS idx_circle_ips_ip ON circle_ips(ip_id);
+
+CREATE TABLE IF NOT EXISTS verification_log (
+  id               INTEGER PRIMARY KEY AUTOINCREMENT,
+  circle_id        INTEGER NOT NULL REFERENCES circles(id) ON DELETE CASCADE,
+  participation_id INTEGER,
+  event_id         INTEGER,
+  source           TEXT NOT NULL,
+  result           TEXT NOT NULL,
+  detail           TEXT,
+  checked_at       TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_verification_circle ON verification_log(circle_id);
+CREATE INDEX IF NOT EXISTS idx_verification_checked ON verification_log(checked_at);

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@vitejs/plugin-react": "^4.3.4",
         "typescript": "^6.0.3",
         "vite": "^6.0.0",
+        "vitest": "^4.1.10",
         "wrangler": "^4.107.0"
       }
     },
@@ -1868,6 +1869,13 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.2.tgz",
@@ -2185,6 +2193,24 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -2239,6 +2265,129 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/baseline-browser-mapping": {
@@ -2315,6 +2464,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -2403,6 +2562,13 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
@@ -2453,6 +2619,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -2916,6 +3102,20 @@
         "node": ">=18"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
@@ -3136,6 +3336,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3145,6 +3352,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "10.2.2",
@@ -3180,6 +3401,23 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -3195,6 +3433,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tslib": {
@@ -3343,6 +3591,113 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/workerd": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,11 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "npm run build && wrangler dev",
-    "deploy": "npm run build && wrangler deploy"
+    "deploy": "npm run build && wrangler deploy",
+    "typecheck": "tsc -p tsconfig.json && tsc -p worker/tsconfig.json",
+    "test": "NODE_OPTIONS=--experimental-sqlite vitest run",
+    "db:migrate:local": "wrangler d1 migrations apply gbc-seoko-db --local",
+    "db:seed:local": "wrangler d1 execute gbc-seoko-db --local --file=seeds/dev.sql"
   },
   "dependencies": {
     "hono": "^4.12.27",
@@ -23,6 +27,7 @@
     "@vitejs/plugin-react": "^4.3.4",
     "typescript": "^6.0.3",
     "vite": "^6.0.0",
+    "vitest": "^4.1.10",
     "wrangler": "^4.107.0"
   }
 }

--- a/seeds/dev.sql
+++ b/seeds/dev.sql
@@ -1,0 +1,25 @@
+-- Minimal development seed. Not applied by `d1 migrations apply`; run explicitly
+-- (see README "로컬 DB"). Enough data to exercise list/detail/filter/통판 paths.
+
+INSERT INTO events (slug, title, alias, fare_id, date_label, start_date, end_date, venue, map_url, status)
+VALUES ('cw-2026-07', '코믹월드 SUMMER 2026', '7월 서코', 334, '2026-07-18~19', '2026-07-18', '2026-07-19', '일산 킨텍스 제1전시장', 'https://example.com/map', 'active');
+
+INSERT INTO ips (name) VALUES ('걸즈밴드크라이');
+
+INSERT INTO circles (slug, name) VALUES
+  ('sample-booth', '샘플 부스 서클'),
+  ('sample-tsuhan', '샘플 통판 서클');
+
+INSERT INTO participations (circle_id, event_id, genre_label, genre_tags, booth, day, booth_url, highlight, badge, note, status)
+VALUES
+  ((SELECT id FROM circles WHERE slug='sample-booth'),  (SELECT id FROM events WHERE slug='cw-2026-07'), '걸밴크', '["걸밴크","오리지널"]', 'A-01', '18', 'https://example.com/booth', 1, '전문', '샘플 노트', 'confirmed'),
+  ((SELECT id FROM circles WHERE slug='sample-tsuhan'), (SELECT id FROM events WHERE slug='cw-2026-07'), '걸밴크', '["걸밴크"]', NULL, NULL, NULL, 0, NULL, '통판 전용', 'unlisted');
+
+INSERT INTO circle_ips (circle_id, ip_id)
+SELECT c.id, i.id FROM circles c, ips i WHERE i.name='걸즈밴드크라이';
+
+INSERT INTO links (participation_id, kind, label, url, sort_order)
+VALUES ((SELECT p.id FROM participations p JOIN circles c ON c.id=p.circle_id WHERE c.slug='sample-booth'), 'x', 'X(트위터)', 'https://x.com/sample', 0);
+
+INSERT INTO tweet_infos (participation_id, url, og_title, og_description, og_image, og_site_name)
+VALUES ((SELECT p.id FROM participations p JOIN circles c ON c.id=p.circle_id WHERE c.slug='sample-booth'), 'https://x.com/sample/status/1', '샘플 트윗', '설명', 'https://example.com/og.png', 'X');

--- a/src/api.ts
+++ b/src/api.ts
@@ -50,12 +50,16 @@ function toCircle(c: ApiCircle): Circle {
   };
 }
 
+/** Pick the active event, falling back to the first (most recent) or null. */
+export function pickActiveEvent(events: ApiEvent[]): ApiEvent | null {
+  return events.find((e) => e.status === "active") ?? events[0] ?? null;
+}
+
 export async function fetchActiveEvent(): Promise<ApiEvent | null> {
   const res = await fetch("/api/events");
   if (!res.ok) throw new Error("이벤트 정보를 불러오지 못했어요");
   const data = await res.json();
-  const events: ApiEvent[] = data.events || [];
-  return events.find((e) => e.status === "active") ?? events[0] ?? null;
+  return pickActiveEvent(data.events || []);
 }
 
 export async function fetchCircles(

--- a/test/client/api.test.ts
+++ b/test/client/api.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { pickActiveEvent, type ApiEvent } from "../../src/api";
+
+const ev = (slug: string, status: string): ApiEvent =>
+  ({ id: 1, slug, title: slug, alias: null, fare_id: null, date_label: null, start_date: null, end_date: null, venue: null, map_url: null, status }) as ApiEvent;
+
+describe("pickActiveEvent", () => {
+  it("returns null for an empty list", () => {
+    expect(pickActiveEvent([])).toBeNull();
+  });
+  it("prefers the active event", () => {
+    expect(pickActiveEvent([ev("a", "past"), ev("b", "active")])?.slug).toBe("b");
+  });
+  it("falls back to the first event when none are active", () => {
+    expect(pickActiveEvent([ev("a", "past"), ev("b", "past")])?.slug).toBe("a");
+  });
+});

--- a/test/helpers/d1.ts
+++ b/test/helpers/d1.ts
@@ -1,0 +1,71 @@
+import { DatabaseSync } from "node:sqlite";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Minimal D1Database shim over node:sqlite for tests. Implements the surface
+ * worker/app.ts uses: prepare().bind().{run,all,first} and batch().
+ */
+export function makeTestDB(): D1Database {
+  const db = new DatabaseSync(":memory:");
+  db.exec("PRAGMA foreign_keys = ON");
+  const migration = readFileSync(
+    fileURLToPath(new URL("../../migrations/0001_init.sql", import.meta.url)),
+    "utf8",
+  );
+  db.exec(migration);
+  return wrap(db);
+}
+
+function wrap(db: DatabaseSync): D1Database {
+  const makeStmt = (sql: string, params: unknown[]): D1PreparedStatement => {
+    const bound = params.map((p) => (typeof p === "boolean" ? (p ? 1 : 0) : p));
+    return {
+      bind: (...args: unknown[]) => makeStmt(sql, args),
+      async run() {
+        const info = db.prepare(sql).run(...(bound as any));
+        return {
+          success: true,
+          meta: { changes: Number(info.changes), last_row_id: Number(info.lastInsertRowid) },
+        } as any;
+      },
+      async all<T = unknown>() {
+        const results = db.prepare(sql).all(...(bound as any)) as T[];
+        return { success: true, results, meta: {} } as any;
+      },
+      async first<T = unknown>(col?: string) {
+        const row = db.prepare(sql).get(...(bound as any)) as any;
+        if (!row) return null;
+        return (col ? row[col] : row) as T;
+      },
+      async raw() {
+        return db.prepare(sql).all(...(bound as any)) as any;
+      },
+    } as unknown as D1PreparedStatement;
+  };
+
+  return {
+    prepare: (sql: string) => makeStmt(sql, []),
+    async batch(statements: D1PreparedStatement[]) {
+      // node:sqlite is synchronous; emulate atomicity with an explicit txn.
+      db.exec("BEGIN");
+      try {
+        const out = [];
+        for (const s of statements) out.push(await (s as any).run());
+        db.exec("COMMIT");
+        return out as any;
+      } catch (e) {
+        db.exec("ROLLBACK");
+        throw e;
+      }
+    },
+    async exec(sql: string) {
+      db.exec(sql);
+      return { count: 0, duration: 0 } as any;
+    },
+    dump: async () => new ArrayBuffer(0),
+    withSession: (() => {
+      throw new Error("not implemented");
+    }) as any,
+  } as unknown as D1Database;
+}

--- a/test/worker/api.test.ts
+++ b/test/worker/api.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { app } from "../../worker/app";
+import { makeTestDB } from "../helpers/d1";
+
+const TOKEN = "test-token";
+
+function makeEnv() {
+  return { DB: makeTestDB(), ADMIN_TOKEN: TOKEN };
+}
+
+async function call(env: any, method: string, path: string, body?: unknown, auth = true) {
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (auth) headers.authorization = `Bearer ${TOKEN}`;
+  const res = await app.fetch(
+    new Request(`http://x${path}`, {
+      method,
+      headers,
+      body: body === undefined ? undefined : JSON.stringify(body),
+    }),
+    env,
+  );
+  return { status: res.status, json: await res.json().catch(() => null) };
+}
+
+describe("worker API", () => {
+  let env: any;
+  beforeEach(() => {
+    env = makeEnv();
+  });
+
+  it("rejects mutations without a valid bearer token", async () => {
+    const r = await call(env, "POST", "/api/events", { slug: "e", title: "t" }, false);
+    expect(r.status).toBe(401);
+  });
+
+  it("creates an event and lists it", async () => {
+    const created = await call(env, "POST", "/api/events", {
+      slug: "cw-2026-07",
+      title: "코믹월드",
+      status: "active",
+    });
+    expect(created.status).toBe(201);
+    const list = await call(env, "GET", "/api/events");
+    expect(list.status).toBe(200);
+    expect(list.json.events.map((e: any) => e.slug)).toContain("cw-2026-07");
+  });
+
+  it("upserts a circle and serializes it in list + detail", async () => {
+    await call(env, "POST", "/api/events", { slug: "ev", title: "T", status: "active" });
+    const up = await call(env, "POST", "/api/circles", {
+      slug: "circ",
+      name: "서클",
+      event_slug: "ev",
+      genre_label: "걸밴크",
+      genre_tags: ["걸밴크", "오리지널"],
+      booth: "A-01",
+      highlight: true,
+      ips: ["걸즈밴드크라이"],
+      links: [{ kind: "x", label: "X", url: "https://x.com/a" }],
+      tweetInfo: { url: "https://x.com/a/status/1", ogTitle: "t" },
+    });
+    expect(up.status).toBe(201);
+
+    const list = await call(env, "GET", "/api/circles?event=ev");
+    expect(list.status).toBe(200);
+    const c = list.json.circles[0];
+    expect(c.slug).toBe("circ");
+    expect(c.genres).toEqual(["걸밴크", "오리지널"]);
+    expect(c.ips).toEqual(["걸즈밴드크라이"]);
+    expect(c.highlight).toBe(true);
+    expect(c.links).toHaveLength(1);
+    expect(c.tweetInfo.ogTitle).toBe("t");
+
+    const detail = await call(env, "GET", "/api/circles/circ?event=ev");
+    expect(detail.json.circle.name).toBe("서클");
+  });
+
+  it("hides unlisted circles by default and reveals them with status=all", async () => {
+    await call(env, "POST", "/api/events", { slug: "ev", title: "T", status: "active" });
+    await call(env, "POST", "/api/circles", { slug: "conf", name: "C", event_slug: "ev", status: "confirmed" });
+    await call(env, "POST", "/api/circles", { slug: "unl", name: "U", event_slug: "ev", status: "unlisted" });
+
+    const def = await call(env, "GET", "/api/circles?event=ev");
+    expect(def.json.circles.map((c: any) => c.slug)).toEqual(["conf"]);
+
+    const all = await call(env, "GET", "/api/circles?event=ev&status=all");
+    expect(all.json.circles.map((c: any) => c.slug).sort()).toEqual(["conf", "unl"]);
+  });
+
+  it("re-upsert updates the existing participation instead of duplicating", async () => {
+    await call(env, "POST", "/api/events", { slug: "ev", title: "T", status: "active" });
+    await call(env, "POST", "/api/circles", { slug: "c", name: "N1", event_slug: "ev" });
+    await call(env, "POST", "/api/circles", { slug: "c", name: "N2", event_slug: "ev", booth: "B-02" });
+    const list = await call(env, "GET", "/api/circles?event=ev&status=all");
+    expect(list.json.circles).toHaveLength(1);
+    expect(list.json.circles[0].name).toBe("N2");
+    expect(list.json.circles[0].booth).toBe("B-02");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["test/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
Closes #7

## 요약
새 환경 재현과 회귀 방지를 위한 기반을 구축한다.

- **마이그레이션**: `migrations/0001_init.sql`가 현재 D1 스키마를 재현 (events / circles / participations / links / tweet_infos / ips / circle_ips / verification_log). 빈 로컬 D1를 `npm run db:migrate:local`만으로 구성 가능.
- **seed**: `seeds/dev.sql` (마이그레이션과 분리 — 프로덕션 마이그레이션에 섞이지 않음), `npm run db:seed:local`.
- **테스트**: Node 내장 `node:sqlite` 기반 D1 shim(`test/helpers/d1.ts`)으로 무거운 workers-pool 없이 Hono 앱을 실제 스키마에 대해 통합 테스트. 클라이언트 `pickActiveEvent` 단위 테스트 포함.
- **스크립트**: `typecheck`(클라이언트+Worker), `test`(vitest), `db:migrate:local`, `db:seed:local`.
- **CI**: `.github/workflows/ci.yml` — PR마다 install → typecheck → test → build (Node 24).

## 검증
- [x] `npm run typecheck` 통과
- [x] `npm test` 8 pass
- [x] `npm run build` 통과
- [x] 빈 로컬 D1 → `db:migrate:local` → `db:seed:local` 확인

## Test plan
- [ ] CI가 PR에서 녹색인지 확인