### PR TITLE
feat: 행사 정보·방문 체크·장르 필터를 활성 행사 기준으로 동적 구성 (#2)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,16 +1,24 @@
 import { useEffect, useMemo, useState } from "react";
 import type { Circle } from "./types";
-import { fetchActiveEvent, fetchCircles } from "./api";
-import { badgeColor, filterCircles, STATUS, type Status } from "./lib/circle";
+import { fetchActiveEvent, fetchCircles, type ApiEvent } from "./api";
+import { badgeColor, deriveGenres, filterCircles, STATUS, type Status } from "./lib/circle";
 import { useChecks } from "./hooks/useChecks";
 import { Card } from "./components/Card";
 import { Detail } from "./components/Detail";
 
-const GENRES = ["걸즈밴드크라이", "뱅드림", "케이온", "봇치더록"];
+const DEFAULT_MAP_URL = "https://comicw.net/map/";
+
+/** 행사 부제: 별칭·장소·기간 중 존재하는 것만 · 로 잇는다. */
+function eventSubtitle(event: ApiEvent | null): string {
+  if (!event) return "행사 정보를 불러오는 중…";
+  const parts = [event.alias || event.title, event.venue, event.date_label].filter(Boolean);
+  return parts.length ? parts.join(" · ") : event.title;
+}
 
 /* ---------- 앱 ---------- */
 export default function App() {
-  const [checks, toggle] = useChecks();
+  const [event, setEvent] = useState<ApiEvent | null>(null);
+  const [checks, toggle] = useChecks(event?.slug ?? null);
   const [status, setStatus] = useState<Status>("all");
   const [genres, setGenres] = useState<string[]>([]);
   const [query, setQuery] = useState("");
@@ -18,9 +26,14 @@ export default function App() {
 
   const [circles, setCircles] = useState<Circle[]>([]);
   const [witchformExtra, setWitchformExtra] = useState<Circle[]>([]);
-  const [mapUrl, setMapUrl] = useState("https://comicw.net/map/");
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
+
+  const mapUrl = event?.map_url || DEFAULT_MAP_URL;
+  const availableGenres = useMemo(
+    () => deriveGenres([...circles, ...witchformExtra]),
+    [circles, witchformExtra],
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -32,9 +45,9 @@ export default function App() {
         if (!ev) throw new Error("등록된 행사가 없어요");
         const { circles: cs, witchformExtra: wf } = await fetchCircles(ev.slug);
         if (cancelled) return;
+        setEvent(ev);
         setCircles(cs);
         setWitchformExtra(wf);
-        setMapUrl(ev.map_url || "https://comicw.net/map/");
       } catch (e) {
         if (!cancelled) setLoadError(e instanceof Error ? e.message : "불러오기 실패");
       } finally {
@@ -83,7 +96,7 @@ export default function App() {
                 걸밴크 서코
               </div>
               <div className="text-xs font-semibold text-faint mt-[5px]">
-                334회 · 7코 일산 킨텍스 · 7/18–19
+                {eventSubtitle(event)}
               </div>
             </div>
 
@@ -168,7 +181,7 @@ export default function App() {
             <button onClick={() => setGenres([])} className={genreChip(genres.length === 0)}>
               전체 장르
             </button>
-            {GENRES.map((g) => (
+            {availableGenres.map((g) => (
               <button
                 key={g}
                 onClick={() =>

--- a/src/hooks/useChecks.ts
+++ b/src/hooks/useChecks.ts
@@ -1,25 +1,28 @@
 import { useEffect, useState } from "react";
+import { type Checks, loadChecks, saveChecks } from "../lib/checks";
 
-const STORAGE_KEY = "gbc-seoko-2026-07-checks";
+/**
+ * 행사별 방문 체크 상태(localStorage). eventSlug가 바뀌면 해당 행사의 저장분을
+ * 다시 불러오고, 변경은 즉시 그 행사의 키에만 기록해 행사 간 상태가 섞이지 않는다.
+ */
+export function useChecks(eventSlug: string | null): [Checks, (id: string) => void, () => void] {
+  const [checks, setChecks] = useState<Checks>({});
 
-export type Checks = Record<string, boolean>;
-
-/* ---------- 방문 체크 상태: localStorage ---------- */
-export function useChecks(): [Checks, (id: string) => void, () => void] {
-  const [checks, setChecks] = useState<Checks>(() => {
-    try {
-      return JSON.parse(localStorage.getItem(STORAGE_KEY) || "{}") || {};
-    } catch {
-      return {};
-    }
-  });
   useEffect(() => {
-    try {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(checks));
-    } catch {
-      /* private mode / quota */
-    }
-  }, [checks]);
-  const toggle = (id: string) => setChecks((c) => ({ ...c, [id]: !c[id] }));
-  return [checks, toggle, () => setChecks({})];
+    setChecks(eventSlug ? loadChecks(localStorage, eventSlug) : {});
+  }, [eventSlug]);
+
+  const toggle = (id: string) =>
+    setChecks((prev) => {
+      const next = { ...prev, [id]: !prev[id] };
+      if (eventSlug) saveChecks(localStorage, eventSlug, next);
+      return next;
+    });
+
+  const reset = () => {
+    if (eventSlug) saveChecks(localStorage, eventSlug, {});
+    setChecks({});
+  };
+
+  return [checks, toggle, reset];
 }

--- a/src/lib/checks.ts
+++ b/src/lib/checks.ts
@@ -1,0 +1,51 @@
+export type Checks = Record<string, boolean>;
+
+/** localStorage 최소 인터페이스 (테스트에서 가짜 객체 주입 가능). */
+export interface KV {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+// API 전환 이전의 단일 키. 최초 활성 행사로 1회 이관 후 이후 행사는 독립적으로 시작한다.
+const LEGACY_KEY = "gbc-seoko-2026-07-checks";
+const MIGRATED_FLAG = "gbc-seoko-checks-migrated";
+
+export const checksKey = (eventSlug: string) => `gbc-seoko-checks:${eventSlug}`;
+
+function parse(raw: string | null): Checks {
+  if (!raw) return {};
+  try {
+    const v = JSON.parse(raw);
+    return v && typeof v === "object" ? (v as Checks) : {};
+  } catch {
+    return {};
+  }
+}
+
+export function saveChecks(kv: KV, eventSlug: string, checks: Checks): void {
+  try {
+    kv.setItem(checksKey(eventSlug), JSON.stringify(checks));
+  } catch {
+    /* private mode / quota */
+  }
+}
+
+/**
+ * 행사별 방문 체크를 불러온다. 새 키가 없고 아직 이관 전이면 레거시 단일 키를
+ * 이 행사로 1회 이관한다(호환 정책). 이후 행사는 빈 상태로 시작한다.
+ */
+export function loadChecks(kv: KV, eventSlug: string): Checks {
+  const existing = kv.getItem(checksKey(eventSlug));
+  if (existing !== null) return parse(existing);
+
+  if (kv.getItem(MIGRATED_FLAG) === null) {
+    const legacy = kv.getItem(LEGACY_KEY);
+    kv.setItem(MIGRATED_FLAG, "1");
+    if (legacy !== null) {
+      const migrated = parse(legacy);
+      saveChecks(kv, eventSlug, migrated);
+      return migrated;
+    }
+  }
+  return {};
+}

--- a/src/lib/circle.ts
+++ b/src/lib/circle.ts
@@ -49,6 +49,18 @@ export const chipsFor = (c: Circle): Chip[] => {
 
 export const norm = (s: string) => s.replace(/\s/g, "");
 
+/** 서클 데이터에 실제로 존재하는 장르 목록(중복 제거·정렬). 필터 칩 생성용. */
+export function deriveGenres(circles: Circle[]): string[] {
+  const set = new Set<string>();
+  for (const c of circles) {
+    for (const g of c.genres || []) {
+      const t = g.trim();
+      if (t) set.add(t);
+    }
+  }
+  return [...set].sort((a, b) => a.localeCompare(b, "ko"));
+}
+
 export type Status = "all" | "done" | "undone";
 export const STATUS: { k: Status; label: string }[] = [
   { k: "all", label: "전체" },

--- a/test/client/checks.test.ts
+++ b/test/client/checks.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { loadChecks, saveChecks, checksKey, type KV } from "../../src/lib/checks";
+
+function fakeKV(seed: Record<string, string> = {}): KV & { store: Map<string, string> } {
+  const store = new Map(Object.entries(seed));
+  return {
+    store,
+    getItem: (k) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k, v) => void store.set(k, v),
+  };
+}
+
+describe("per-event checks", () => {
+  it("keys visits by event slug so events don't mix", () => {
+    const kv = fakeKV();
+    saveChecks(kv, "ev-a", { x: true });
+    saveChecks(kv, "ev-b", { y: true });
+    expect(loadChecks(kv, "ev-a")).toEqual({ x: true });
+    expect(loadChecks(kv, "ev-b")).toEqual({ y: true });
+    expect(kv.store.has(checksKey("ev-a"))).toBe(true);
+  });
+
+  it("migrates the legacy single key into the first loaded event once", () => {
+    const kv = fakeKV({ "gbc-seoko-2026-07-checks": JSON.stringify({ cf62: true }) });
+    expect(loadChecks(kv, "cw-2026-07")).toEqual({ cf62: true });
+    // second, different event starts empty (legacy already consumed)
+    expect(loadChecks(kv, "other-event")).toEqual({});
+  });
+
+  it("returns empty when no data and no legacy", () => {
+    expect(loadChecks(fakeKV(), "ev")).toEqual({});
+  });
+
+  it("survives corrupted stored JSON", () => {
+    const kv = fakeKV({ [checksKey("ev")]: "{broken" });
+    expect(loadChecks(kv, "ev")).toEqual({});
+  });
+});

--- a/test/client/circle.test.ts
+++ b/test/client/circle.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { filterCircles, chipLabel, boothShort, chipsFor } from "../../src/lib/circle";
+import { filterCircles, chipLabel, boothShort, chipsFor, deriveGenres } from "../../src/lib/circle";
 import type { Circle } from "../../src/types";
 
 const mk = (o: Partial<Circle> & { id: string }): Circle => ({
@@ -62,6 +62,15 @@ describe("helpers", () => {
   it("boothShort takes leading booth or name initial", () => {
     expect(boothShort(mk({ id: "x", booth: "BE01·BE02" }))).toBe("BE01");
     expect(boothShort(mk({ id: "x", name: "통판", booth: undefined }))).toBe("통");
+  });
+
+  it("deriveGenres collects unique sorted genres present in the data", () => {
+    const circles = [
+      mk({ id: "a", genres: ["뱅드림", "걸밴크"] }),
+      mk({ id: "b", genres: ["걸밴크", "  "] }),
+      mk({ id: "c" }),
+    ];
+    expect(deriveGenres(circles)).toEqual(["걸밴크", "뱅드림"]);
   });
 
   it("chipsFor puts boothUrl first as primary", () => {


### PR DESCRIPTION
Closes #2

> ⛓️ **스택 PR** — base가 `feature/6-write-api-hardening`(#6). 병합 순서: #7 → #5 → #6 → **#2** → #3 → #4.

## 요약
- **동적 행사 정보**: 활성 행사를 상태로 유지하고 부제를 `별칭 · 장소 · 기간`으로 표시. `map_url`도 행사에서 파생. 행사가 바뀌면 화면 정보가 그대로 갱신.
- **행사별 방문 체크**: 저장 키를 `gbc-seoko-checks:<slug>`로 분리 → 행사 간 체크가 섞이지 않음.
- **호환 정책**: 레거시 단일 키(`gbc-seoko-2026-07-checks`)는 최초 로드되는 활성 행사로 **1회 이관**되고, 이후 행사는 독립적으로 시작 (`MIGRATED_FLAG`로 재이관 방지).
- **데이터 기반 장르 필터**: `deriveGenres`가 서클 데이터의 `genres`에서 실제 존재하는 장르만 중복 제거·정렬해 칩 생성 (하드코딩 목록 제거).
- **fallback**: 행사/필드 누락 시 부제·mapUrl 기본값.

## 테스트 가능성
저장 키·이관 로직은 `src/lib/checks.ts`로 순수화해 가짜 `KV`로 테스트, 장르 파생은 `deriveGenres` 순수 함수로 테스트.

## 검증
- [x] `npm run typecheck` 통과
- [x] `npm test` 29 pass (행사별 키·레거시 이관·손상 JSON·deriveGenres)
- [x] `npm run build` 통과