### PR TITLE
feat: 상세 URL 라우팅 + 오류 재시도 + 필터 접근성 개선 (#4)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import type { Circle } from "./types";
 import { fetchActiveEvent, fetchCircles, type ApiEvent } from "./api";
 import { badgeColor, deriveGenres, filterCircles, STATUS, type Status } from "./lib/circle";
 import { useChecks } from "./hooks/useChecks";
+import { useDetailRoute } from "./hooks/useDetailRoute";
 import { Card } from "./components/Card";
 import { Detail } from "./components/Detail";
 
@@ -22,7 +23,8 @@ export default function App() {
   const [status, setStatus] = useState<Status>("all");
   const [genres, setGenres] = useState<string[]>([]);
   const [query, setQuery] = useState("");
-  const [detailId, setDetailId] = useState<string | null>(null);
+  const [detailId, openDetail, closeDetail] = useDetailRoute();
+  const [announce, setAnnounce] = useState("");
 
   const [circles, setCircles] = useState<Circle[]>([]);
   const [witchformExtra, setWitchformExtra] = useState<Circle[]>([]);
@@ -34,29 +36,31 @@ export default function App() {
   const all = useMemo(() => [...circles, ...witchformExtra], [circles, witchformExtra]);
   const availableGenres = useMemo(() => deriveGenres(all), [all]);
 
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        setLoading(true);
-        setLoadError(null);
-        const ev = await fetchActiveEvent();
-        if (!ev) throw new Error("등록된 행사가 없어요");
-        const { circles: cs, witchformExtra: wf } = await fetchCircles(ev.slug);
-        if (cancelled) return;
-        setEvent(ev);
-        setCircles(cs);
-        setWitchformExtra(wf);
-      } catch (e) {
-        if (!cancelled) setLoadError(e instanceof Error ? e.message : "불러오기 실패");
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
+  const load = useCallback(async () => {
+    try {
+      setLoading(true);
+      setLoadError(null);
+      const ev = await fetchActiveEvent();
+      if (!ev) throw new Error("등록된 행사가 없어요");
+      const { circles: cs, witchformExtra: wf } = await fetchCircles(ev.slug);
+      setEvent(ev);
+      setCircles(cs);
+      setWitchformExtra(wf);
+    } catch (e) {
+      setLoadError(e instanceof Error ? e.message : "불러오기 실패");
+    } finally {
+      setLoading(false);
+    }
   }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const handleToggle = (id: string) => {
+    setAnnounce(checks[id] ? "방문 체크를 해제했어요" : "방문 체크했어요");
+    toggle(id);
+  };
 
   // 진행률은 통판 포함(모두 방문 대상) — 제품 규칙
   const doneCount = all.filter((c) => checks[c.id]).length;
@@ -79,12 +83,15 @@ export default function App() {
 
   return (
     <div className="min-h-screen bg-bg max-w-[520px] mx-auto">
+      <div role="status" aria-live="polite" className="sr-only">
+        {announce}
+      </div>
       {detail ? (
         <Detail
           item={detail}
           checked={!!checks[detail.id]}
-          onToggle={() => toggle(detail.id)}
-          onBack={() => setDetailId(null)}
+          onToggle={() => handleToggle(detail.id)}
+          onBack={closeDetail}
           color={badgeColor(detail.id, all)}
         />
       ) : (
@@ -114,9 +121,11 @@ export default function App() {
                 <path d="M21 21l-4-4" />
               </svg>
               <input
+                type="search"
                 value={query}
                 onChange={(e) => setQuery(e.target.value)}
                 placeholder="서클 · 부스 · 장르 검색"
+                aria-label="서클·부스·장르 검색"
                 className="flex-1 min-w-0 border-0 outline-none bg-transparent text-[16px] text-ink placeholder:text-faint"
               />
               {query ? (
@@ -168,6 +177,7 @@ export default function App() {
                 <button
                   key={s.k}
                   onClick={() => setStatus(s.k)}
+                  aria-pressed={status === s.k}
                   className={statusChip(status === s.k)}
                 >
                   {s.label}
@@ -178,7 +188,11 @@ export default function App() {
 
           {/* 장르 칩 (가로 스크롤) */}
           <div className="flex gap-2 overflow-x-auto no-scrollbar px-5 pt-1 pb-0.5">
-            <button onClick={() => setGenres([])} className={genreChip(genres.length === 0)}>
+            <button
+              onClick={() => setGenres([])}
+              aria-pressed={genres.length === 0}
+              className={genreChip(genres.length === 0)}
+            >
               전체 장르
             </button>
             {availableGenres.map((g) => (
@@ -189,6 +203,7 @@ export default function App() {
                     prev.includes(g) ? prev.filter((x) => x !== g) : [...prev, g],
                   )
                 }
+                aria-pressed={genres.includes(g)}
                 className={genreChip(genres.includes(g))}
               >
                 {g}
@@ -207,8 +222,15 @@ export default function App() {
           {/* 카드 목록 */}
           <div className="flex flex-col gap-3 px-5">
             {loadError && (
-              <div className="text-center py-14 text-[#e0455c] text-sm font-semibold">
-                {loadError} · 새로고침해서 다시 시도해주세요
+              <div className="text-center py-14" role="alert">
+                <div className="text-[#e0455c] text-sm font-semibold">{loadError}</div>
+                <button
+                  onClick={() => void load()}
+                  disabled={loading}
+                  className="mt-3 inline-flex items-center h-9 px-4 rounded-full bg-ink text-white text-[13px] font-bold cursor-pointer border-0 disabled:opacity-60"
+                >
+                  {loading ? "다시 시도 중…" : "다시 시도"}
+                </button>
               </div>
             )}
             {!loadError && loading && circles.length === 0 && (
@@ -222,8 +244,8 @@ export default function App() {
                   key={c.id}
                   item={c}
                   checked={!!checks[c.id]}
-                  onToggle={() => toggle(c.id)}
-                  onOpen={() => setDetailId(c.id)}
+                  onToggle={() => handleToggle(c.id)}
+                  onOpen={() => openDetail(c.id)}
                   color={badgeColor(c.id, all)}
                 />
               ))}
@@ -243,8 +265,8 @@ export default function App() {
                     key={c.id}
                     item={c}
                     checked={!!checks[c.id]}
-                    onToggle={() => toggle(c.id)}
-                    onOpen={() => setDetailId(c.id)}
+                    onToggle={() => handleToggle(c.id)}
+                    onOpen={() => openDetail(c.id)}
                     color={badgeColor(c.id, all)}
                   />
                 ))}

--- a/src/components/Detail.tsx
+++ b/src/components/Detail.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import type { Circle } from "../types";
 import { boothShort } from "../lib/circle";
 import { TweetCard } from "./TweetCard";
@@ -16,6 +17,12 @@ export function Detail({
   onBack: () => void;
   color: string;
 }) {
+  const backRef = useRef<HTMLButtonElement>(null);
+  // 상세 진입 시 포커스를 상세 컨텍스트(뒤로 버튼)로 이동 — 키보드/스크린리더 대응
+  useEffect(() => {
+    backRef.current?.focus();
+  }, [item.id]);
+
   const short = boothShort(item);
   const links: { label: string; url: string; primary: boolean }[] = [];
   if (item.boothUrl)
@@ -30,8 +37,9 @@ export function Detail({
     <div>
       <div className="sticky top-0 z-10 bg-bg flex items-center gap-1.5 px-4 pt-5 pb-3.5">
         <button
+          ref={backRef}
           onClick={onBack}
-          aria-label="뒤로"
+          aria-label="목록으로 뒤로"
           className="w-10 h-10 rounded-xl flex items-center justify-center cursor-pointer bg-transparent border-0"
         >
           <svg

--- a/src/hooks/useDetailRoute.ts
+++ b/src/hooks/useDetailRoute.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from "react";
+import { parseDetailId, detailHash } from "../lib/route";
+
+/**
+ * 상세 화면 상태를 URL 해시와 동기화. 직접 진입(초기 해시 파싱)과 브라우저
+ * 뒤로가기(hashchange)를 지원한다. 상태 갱신은 낙관적으로도 반영해 이벤트
+ * 전달이 불안정한 환경(jsdom 등)에서도 UI가 즉시 반응한다.
+ */
+export function useDetailRoute(): [string | null, (id: string) => void, () => void] {
+  const [id, setId] = useState<string | null>(() => parseDetailId(window.location.hash));
+
+  useEffect(() => {
+    const onChange = () => setId(parseDetailId(window.location.hash));
+    window.addEventListener("hashchange", onChange);
+    return () => window.removeEventListener("hashchange", onChange);
+  }, []);
+
+  const open = (detailId: string) => {
+    setId(detailId);
+    window.location.hash = detailHash(detailId);
+  };
+
+  const close = () => {
+    setId(null);
+    // 열 때 히스토리 항목이 쌓였으므로 뒤로가기로 목록에 복귀(브라우저 back과 동일 경로).
+    if (parseDetailId(window.location.hash)) window.history.back();
+  };
+
+  return [id, open, close];
+}

--- a/src/lib/route.ts
+++ b/src/lib/route.ts
@@ -1,0 +1,11 @@
+// 상세 화면 라우팅 — 해시 기반. (vite base가 "./"라 deep-path 라우팅은 에셋 경로가
+// 깨지므로 해시를 쓴다. 직접 진입/뒤로가기 모두 루트 경로에서 동작.)
+
+/** location.hash → 상세 서클 id (없으면 null). */
+export function parseDetailId(hash: string): string | null {
+  const m = /^#?\/c\/(.+)$/.exec(hash);
+  return m ? decodeURIComponent(m[1]) : null;
+}
+
+/** 상세 서클 id → location.hash 문자열. */
+export const detailHash = (id: string) => `#/c/${encodeURIComponent(id)}`;

--- a/test/client/App.test.tsx
+++ b/test/client/App.test.tsx
@@ -47,6 +47,7 @@ const CIRCLES = [
 describe("<App/> confirmed + unlisted", () => {
   beforeEach(() => {
     localStorage.clear();
+    window.location.hash = ""; // 라우팅 상태 격리 (테스트 간 hash 누수 방지)
     mockApi(CIRCLES);
   });
   afterEach(() => {

--- a/test/client/a11y-routing.test.tsx
+++ b/test/client/a11y-routing.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
+import App from "../../src/App";
+import { parseDetailId, detailHash } from "../../src/lib/route";
+
+const EVENT = {
+  id: 1,
+  slug: "ev",
+  title: "코믹월드",
+  alias: "별칭",
+  venue: "장소",
+  date_label: "기간",
+  map_url: null,
+  status: "active",
+};
+const CIRCLES = [
+  { id: 1, participationId: 1, slug: "booth1", name: "부스서클", genre: "걸밴크", genres: ["걸밴크"], ips: [], booth: "A-01", day: null, boothUrl: null, highlight: false, badge: null, note: null, status: "confirmed", links: [] },
+];
+
+function json(obj: unknown) {
+  return new Response(JSON.stringify(obj), { status: 200, headers: { "content-type": "application/json" } });
+}
+
+describe("route helpers", () => {
+  it("round-trips a detail id through the hash", () => {
+    expect(parseDetailId(detailHash("a b/c"))).toBe("a b/c");
+  });
+  it("returns null for non-detail hashes", () => {
+    expect(parseDetailId("")).toBeNull();
+    expect(parseDetailId("#/other")).toBeNull();
+  });
+});
+
+describe("<App/> accessibility + routing", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    window.location.hash = "";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (url.includes("/api/events")) return json({ events: [EVENT] });
+        if (url.includes("/api/circles")) return json({ circles: CIRCLES });
+        throw new Error("unexpected " + url);
+      }),
+    );
+  });
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("search input has an accessible name and filter toggles expose aria-pressed", async () => {
+    render(<App />);
+    await screen.findByText("부스서클");
+    expect(screen.getByRole("searchbox", { name: "서클·부스·장르 검색" })).toBeTruthy();
+    const allBtn = screen.getByRole("button", { name: "전체" });
+    expect(allBtn.getAttribute("aria-pressed")).toBe("true");
+    const done = screen.getByRole("button", { name: "체크함" });
+    expect(done.getAttribute("aria-pressed")).toBe("false");
+    fireEvent.click(done);
+    expect(screen.getByRole("button", { name: "체크함" }).getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("opening detail updates the hash; hashchange back returns to the list", async () => {
+    render(<App />);
+    fireEvent.click(await screen.findByText("부스서클"));
+    expect(screen.getByText("서클 상세")).toBeTruthy();
+    expect(parseDetailId(window.location.hash)).toBe("booth1");
+
+    // simulate browser back to the list
+    window.location.hash = "";
+    fireEvent(window, new Event("hashchange"));
+    await waitFor(() => expect(screen.queryByText("서클 상세")).toBeNull());
+    expect(screen.getByText("부스서클")).toBeTruthy();
+  });
+
+  it("direct entry to a detail hash renders that circle", async () => {
+    window.location.hash = detailHash("booth1");
+    render(<App />);
+    await waitFor(() => expect(screen.getByText("서클 상세")).toBeTruthy());
+  });
+
+  it("shows a retry button that re-fetches without a page reload", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("네트워크 오류"))
+      .mockImplementation(async (url: string) => {
+        if (url.includes("/api/events")) return json({ events: [EVENT] });
+        if (url.includes("/api/circles")) return json({ circles: CIRCLES });
+        throw new Error("unexpected " + url);
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<App />);
+    const retry = await screen.findByRole("button", { name: /다시 시도/ });
+    fireEvent.click(retry);
+    expect(await screen.findByText("부스서클")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Closes #4

> ⛓️ **스택 PR** — base가 `feature/3-unlisted-circles`(#3). 병합 순서: #7 → #5 → #6 → #2 → #3 → **#4** (마지막).

## 변경
- **상세 라우팅**: `useDetailRoute` + `src/lib/route.ts`로 상세 상태를 URL 해시(`#/c/<slug>`)와 동기화. 브라우저 뒤로가기로 목록 복귀, 상세 URL 직접 진입 지원. (vite `base: "./"` 제약으로 path 대신 해시 채택.)
- **오류 재시도**: 에러 화면에 실제 **다시 시도** 버튼 → `load()` 재호출. 새로고침 불필요. `role="alert"`.
- **접근성**:
  - 검색 입력에 `aria-label` + `type="search"`.
  - 상태/장르 토글 버튼에 `aria-pressed`.
  - 방문 체크 변경 시 `aria-live`(`role="status"`) 안내.
  - 상세 진입 시 포커스를 뒤로 버튼으로 이동.

## 검증
- [x] `npm run typecheck` 통과
- [x] `npm test` 39 pass — route 왕복, aria-label/aria-pressed, 해시 뒤로가기, 직접 진입, 재시도(재요청) 테스트
- [x] `npm run build` 통과
- [x] 모바일 레이아웃/디자인 유지 (재시도 버튼·aria 속성·sr-only 영역만 추가)