### PR TITLE
fix: 장르 필터를 큐레이션된 4개로 되돌림

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,16 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { Circle } from "./types";
 import { fetchActiveEvent, fetchCircles, type ApiEvent } from "./api";
-import { badgeColor, deriveGenres, filterCircles, STATUS, type Status } from "./lib/circle";
+import { badgeColor, filterCircles, STATUS, type Status } from "./lib/circle";
 import { useChecks } from "./hooks/useChecks";
 import { useDetailRoute } from "./hooks/useDetailRoute";
 import { Card } from "./components/Card";
 import { Detail } from "./components/Detail";
 
 const DEFAULT_MAP_URL = "https://comicw.net/map/";
+
+// 필터 칩은 큐레이션된 걸밴크 관련 장르만 노출한다(데이터의 모든 태그를 풀지 않음).
+const GENRES = ["걸즈밴드크라이", "뱅드림", "케이온", "봇치더록"];
 
 /** 행사 부제: 별칭·장소·기간 중 존재하는 것만 · 로 잇는다. */
 function eventSubtitle(event: ApiEvent | null): string {
@@ -34,7 +37,6 @@ export default function App() {
   const mapUrl = event?.map_url || DEFAULT_MAP_URL;
   // 행사장 서클 + 통판(unlisted)을 한 데이터셋으로 다뤄 검색·필터·체크를 일관 적용
   const all = useMemo(() => [...circles, ...witchformExtra], [circles, witchformExtra]);
-  const availableGenres = useMemo(() => deriveGenres(all), [all]);
 
   const load = useCallback(async () => {
     try {
@@ -195,7 +197,7 @@ export default function App() {
             >
               전체 장르
             </button>
-            {availableGenres.map((g) => (
+            {GENRES.map((g) => (
               <button
                 key={g}
                 onClick={() =>

--- a/src/lib/circle.ts
+++ b/src/lib/circle.ts
@@ -49,18 +49,6 @@ export const chipsFor = (c: Circle): Chip[] => {
 
 export const norm = (s: string) => s.replace(/\s/g, "");
 
-/** 서클 데이터에 실제로 존재하는 장르 목록(중복 제거·정렬). 필터 칩 생성용. */
-export function deriveGenres(circles: Circle[]): string[] {
-  const set = new Set<string>();
-  for (const c of circles) {
-    for (const g of c.genres || []) {
-      const t = g.trim();
-      if (t) set.add(t);
-    }
-  }
-  return [...set].sort((a, b) => a.localeCompare(b, "ko"));
-}
-
 export type Status = "all" | "done" | "undone";
 export const STATUS: { k: Status; label: string }[] = [
   { k: "all", label: "전체" },

--- a/test/client/circle.test.ts
+++ b/test/client/circle.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { filterCircles, chipLabel, boothShort, chipsFor, deriveGenres } from "../../src/lib/circle";
+import { filterCircles, chipLabel, boothShort, chipsFor } from "../../src/lib/circle";
 import type { Circle } from "../../src/types";
 
 const mk = (o: Partial<Circle> & { id: string }): Circle => ({
@@ -62,15 +62,6 @@ describe("helpers", () => {
   it("boothShort takes leading booth or name initial", () => {
     expect(boothShort(mk({ id: "x", booth: "BE01·BE02" }))).toBe("BE01");
     expect(boothShort(mk({ id: "x", name: "통판", booth: undefined }))).toBe("통");
-  });
-
-  it("deriveGenres collects unique sorted genres present in the data", () => {
-    const circles = [
-      mk({ id: "a", genres: ["뱅드림", "걸밴크"] }),
-      mk({ id: "b", genres: ["걸밴크", "  "] }),
-      mk({ id: "c" }),
-    ];
-    expect(deriveGenres(circles)).toEqual(["걸밴크", "뱅드림"]);
   });
 
   it("chipsFor puts boothUrl first as primary", () => {


### PR DESCRIPTION
#2에서 도입한 데이터 기반 `deriveGenres`가 서클 데이터의 모든 장르 태그를 필터 칩으로 노출했는데, 원래는 걸밴크 관련 **4개(걸즈밴드크라이 · 뱅드림 · 케이온 · 봇치더록)**만 큐레이션해서 두려던 의도였음. 고정 목록으로 복원하고 미사용이 된 `deriveGenres` + 테스트 제거.

- [x] typecheck / test(38) / build 통과