### PR TITLE
style: 320_archive 참고 디자인 개선

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -137,14 +137,14 @@ export default function App() {
   const detail = detailSlug ? all.find((c) => c.id === detailSlug) ?? null : null;
 
   const statusChip = (active: boolean) =>
-    "inline-flex items-center h-[34px] px-4 rounded-full text-[13.5px] font-bold cursor-pointer whitespace-nowrap border " +
-    (active ? "bg-ink text-white border-ink" : "bg-card text-[#7b818c] border-line");
+    "inline-flex items-center h-[32px] px-3 rounded-[8px] text-[13px] font-medium cursor-pointer whitespace-nowrap border " +
+    (active ? "bg-ink text-bg border-ink" : "bg-card text-muted border-line");
   const genreChip = (active: boolean) =>
-    "inline-flex items-center h-8 px-[13px] rounded-full text-[13px] font-bold cursor-pointer whitespace-nowrap border " +
-    (active ? "bg-accent/10 text-accent border-accent/30" : "bg-card text-[#7b818c] border-line");
+    "inline-flex items-center h-7 px-2.5 rounded-full text-[12px] font-medium cursor-pointer whitespace-nowrap border " +
+    (active ? "bg-accent/10 text-accent border-accent/30" : "bg-card text-muted border-line");
 
   return (
-    <div className="min-h-screen bg-bg max-w-[520px] mx-auto">
+    <div className="min-h-screen bg-bg max-w-[560px] mx-auto border-x border-line">
       <div role="status" aria-live="polite" className="sr-only">
         {announce}
       </div>
@@ -168,7 +168,7 @@ export default function App() {
       ) : (
         <div className="pb-7">
           {/* sticky 헤더 */}
-          <div className="sticky top-0 z-10 bg-bg px-5 pt-[22px] pb-3">
+          <div className="sticky top-0 z-10 bg-bg/95 backdrop-blur px-5 pt-[22px] pb-3 border-b border-line">
             <div className="mb-4 flex items-start justify-between gap-3">
               <div>
                 <div className="text-[22px] font-extrabold -tracking-[0.02em] text-ink leading-none">
@@ -302,7 +302,7 @@ export default function App() {
                 <button
                   onClick={() => void load()}
                   disabled={loading}
-                  className="mt-3 inline-flex items-center h-9 px-4 rounded-full bg-ink text-white text-[13px] font-bold cursor-pointer border-0 disabled:opacity-60"
+                  className="mt-3 inline-flex items-center h-9 px-4 rounded-full bg-ink text-bg text-[13px] font-bold cursor-pointer border-0 disabled:opacity-60"
                 >
                   {loading ? "다시 시도 중…" : "다시 시도"}
                 </button>

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -18,11 +18,9 @@ export function Card({
 }) {
   const short = boothShort(item);
   const cardCls = [
-    "relative rounded-[18px] p-4 bg-card border transition-colors",
-    item.highlight
-      ? "border-transparent ring-[1.6px] ring-accent/40"
-      : "border-[#eeeff2] shadow-[0_1px_2px_rgba(20,22,30,0.04)]",
-    checked ? "!bg-[#f3f5f8] opacity-80" : "",
+    "relative rounded-[10px] p-4 bg-card border border-line transition-colors hover:border-line-strong",
+    item.highlight ? "ring-[1.6px] ring-accent/40" : "",
+    checked ? "bg-chip opacity-60" : "",
   ].join(" ");
 
   return (
@@ -65,7 +63,7 @@ export function Card({
           aria-label={checked ? "방문 체크 해제" : "방문 체크"}
           className={
             "w-[26px] h-[26px] rounded-full flex items-center justify-center flex-none border-2 cursor-pointer transition-colors " +
-            (checked ? "bg-accent border-accent" : "bg-white border-[#d5d7de]")
+            (checked ? "bg-accent border-accent" : "bg-transparent border-line-strong")
           }
         >
           {checked && (
@@ -86,7 +84,7 @@ export function Card({
       </div>
 
       {item.note && (
-        <div className="text-[12.5px] text-[#8a8f98] leading-[1.55] mt-[7px] bg-[#f6f7f9] rounded-[10px] px-[11px] py-[9px]">
+        <div className="text-[12.5px] text-muted leading-[1.55] mt-[7px] bg-chip rounded-[8px] px-[11px] py-[9px]">
           {item.note}
         </div>
       )}
@@ -96,7 +94,7 @@ export function Card({
           {item.ips.map((g) => (
             <span
               key={g}
-              className="inline-flex items-center h-6 px-[9px] rounded-md bg-chip text-[#5b6270] text-[11.5px] font-bold"
+              className="inline-flex items-center h-6 px-[9px] rounded-md bg-chip text-muted text-[11.5px] font-bold"
             >
               {g}
             </span>

--- a/src/components/Detail.tsx
+++ b/src/components/Detail.tsx
@@ -35,19 +35,19 @@ export function Detail({
 
   return (
     <div>
-      <div className="sticky top-0 z-10 bg-bg flex items-center gap-1.5 px-4 pt-5 pb-3.5">
+      <div className="sticky top-0 z-10 bg-bg/95 backdrop-blur flex items-center gap-1.5 px-4 pt-5 pb-3.5 border-b border-line">
         <button
           ref={backRef}
           onClick={onBack}
           aria-label="목록으로 뒤로"
-          className="w-10 h-10 rounded-xl flex items-center justify-center cursor-pointer bg-transparent border-0"
+          className="w-10 h-10 rounded-xl flex items-center justify-center cursor-pointer bg-transparent border-0 text-ink"
         >
           <svg
             viewBox="0 0 24 24"
             width="24"
             height="24"
             fill="none"
-            stroke="#17181c"
+            stroke="currentColor"
             strokeWidth="2"
             strokeLinecap="round"
             strokeLinejoin="round"
@@ -55,7 +55,7 @@ export function Detail({
             <path d="M15 18l-6-6 6-6" />
           </svg>
         </button>
-        <span className="text-[15px] font-bold text-[#3a3d44]">서클 상세</span>
+        <span className="text-[15px] font-bold text-ink">서클 상세</span>
       </div>
 
       <div className="px-[22px] pt-1.5">
@@ -101,7 +101,7 @@ export function Detail({
         {item.note && (
           <div className="mt-5">
             <div className="text-xs font-extrabold tracking-[0.04em] text-faint mb-2">MEMO</div>
-            <div className="text-sm text-[#4b5563] leading-[1.65] bg-card border border-line rounded-2xl px-4 py-[15px]">
+            <div className="text-sm text-muted leading-[1.65] bg-card border border-line rounded-[10px] px-4 py-[15px]">
               {item.note}
             </div>
           </div>
@@ -155,7 +155,7 @@ export function Detail({
           onClick={onToggle}
           className={
             "flex items-center justify-center gap-2 w-full h-[54px] mt-[26px] mb-6 rounded-2xl text-[15.5px] font-extrabold cursor-pointer border-0 text-white " +
-            (checked ? "bg-accent" : "bg-ink")
+            (checked ? "bg-accent" : "bg-ink text-bg")
           }
         >
           {checked && (

--- a/src/index.css
+++ b/src/index.css
@@ -1,16 +1,63 @@
 @import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css");
 @import "tailwindcss";
 
+:root {
+  --app-bg: #0a0a0a;
+  --app-panel: #0f0f0f;
+  --app-panel-2: #141414;
+  --app-raise: #191919;
+  --app-border: #242424;
+  --app-border-strong: #333333;
+  --app-fg: #ededed;
+  --app-fg-2: #a1a1a1;
+  --app-fg-3: #6f6f6f;
+  --app-accent: #3b82f6;
+  --app-accent-soft: rgba(59, 130, 246, .14);
+  color-scheme: dark;
+}
+
+:root[data-theme="light"], :root:not([data-theme]) {
+  --app-bg: #ffffff;
+  --app-panel: #fafafa;
+  --app-panel-2: #f4f4f4;
+  --app-raise: #ffffff;
+  --app-border: #e6e6e6;
+  --app-border-strong: #d4d4d4;
+  --app-fg: #111111;
+  --app-fg-2: #5f5f5f;
+  --app-fg-3: #8b8b8b;
+  --app-accent: #0062d6;
+  --app-accent-soft: rgba(0, 98, 214, .1);
+  color-scheme: light;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme]) {
+    --app-bg: #0a0a0a;
+    --app-panel: #0f0f0f;
+    --app-panel-2: #141414;
+    --app-raise: #191919;
+    --app-border: #242424;
+    --app-border-strong: #333333;
+    --app-fg: #ededed;
+    --app-fg-2: #a1a1a1;
+    --app-fg-3: #6f6f6f;
+    --app-accent: #3b82f6;
+    --app-accent-soft: rgba(59, 130, 246, .14);
+    color-scheme: dark;
+  }
+}
+
 @theme {
-  /* Blink 스타일 팔레트 (구 Newsprint 대체) */
-  --color-bg: #f4f5f7;        /* 앱 배경 */
-  --color-card: #ffffff;      /* 카드 배경 */
-  --color-ink: #17181c;       /* 기본 텍스트 */
-  --color-muted: #6b7280;     /* 본문 보조 텍스트 */
-  --color-faint: #9aa0aa;     /* 메타/라벨 */
-  --color-line: #ecedf0;      /* 보더 */
-  --color-chip: #f1f3f6;      /* 태그/링크 칩 배경 */
-  --color-accent: #3e5bff;    /* 액센트(블루) */
+  --color-bg: var(--app-bg);
+  --color-card: var(--app-panel);
+  --color-ink: var(--app-fg);
+  --color-muted: var(--app-fg-2);
+  --color-faint: var(--app-fg-3);
+  --color-line: var(--app-border);
+  --color-line-strong: var(--app-border-strong);
+  --color-chip: var(--app-panel-2);
+  --color-accent: var(--app-accent);
 
   --font-sans: "Pretendard Variable", Pretendard, -apple-system, BlinkMacSystemFont,
     "Apple SD Gothic Neo", sans-serif;
@@ -19,7 +66,6 @@
 html,
 body {
   margin: 0;
-  /* 모바일에서 페이지 자체가 좌우로 밀리는 것 방지 (칩 줄 내부 스크롤은 유지) */
   overflow-x: hidden;
   overflow-x: clip;
 }
@@ -31,7 +77,6 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
-/* 가로 스크롤 칩 줄: 스크롤바 숨김 */
 .no-scrollbar::-webkit-scrollbar {
   display: none;
 }


### PR DESCRIPTION
## 변경 사항
- 320_archive의 절제된 다크/라이트 테마와 패널 색상 체계 반영
- 카드, 필터 칩, 체크박스, 상세 화면의 보더·라운딩·간격 개선
- sticky 헤더에 반투명 배경과 blur 적용
- 다크 모드에서 버튼과 상세 화면 아이콘의 색상 대비 보정

## 검증
- npm run typecheck
- npm test
- npm run build