### PR TITLE
feat: 행사 날짜 기반 상태 자동 갱신

### DIFF
--- a/test/worker/api.test.ts
+++ b/test/worker/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { app } from "../../worker/app";
+import { app, determineEventStatus } from "../../worker/app";
 import { makeTestDB } from "../helpers/d1";
 
 const TOKEN = "test-token";
@@ -11,6 +11,7 @@ function makeEnv() {
 async function call(env: any, method: string, path: string, body?: unknown, auth = true) {
   const headers: Record<string, string> = { "content-type": "application/json" };
   if (auth) headers.authorization = `Bearer ${TOKEN}`;
+  const backgroundTasks: Promise<unknown>[] = [];
   const res = await app.fetch(
     new Request(`http://x${path}`, {
       method,
@@ -18,7 +19,9 @@ async function call(env: any, method: string, path: string, body?: unknown, auth
       body: body === undefined ? undefined : JSON.stringify(body),
     }),
     env,
+    { waitUntil: (task: Promise<unknown>) => backgroundTasks.push(task) } as ExecutionContext,
   );
+  await Promise.all(backgroundTasks);
   return { status: res.status, json: await res.json().catch(() => null) };
 }
 
@@ -43,6 +46,56 @@ describe("worker API", () => {
     const list = await call(env, "GET", "/api/events");
     expect(list.status).toBe(200);
     expect(list.json.events.map((e: any) => e.slug)).toContain("cw-2026-07");
+  });
+
+  it("determines event status with inclusive event dates", () => {
+    expect(determineEventStatus({ start_date: "2026-09-02", end_date: "2026-09-03", status: "past" }, "2026-09-01")).toBe("upcoming");
+    expect(determineEventStatus({ start_date: "2026-09-02", end_date: "2026-09-03", status: "past" }, "2026-09-02")).toBe("active");
+    expect(determineEventStatus({ start_date: "2026-09-02", end_date: "2026-09-03", status: "past" }, "2026-09-03")).toBe("active");
+    expect(determineEventStatus({ start_date: "2026-09-02", end_date: "2026-09-03", status: "upcoming" }, "2026-09-04")).toBe("past");
+    expect(determineEventStatus({ start_date: null, end_date: null, status: "upcoming" }, "2026-09-01")).toBe("upcoming");
+  });
+
+  it("rejects invalid or reversed event dates", async () => {
+    expect((await call(env, "POST", "/api/events", {
+      slug: "invalid-date",
+      title: "잘못된 날짜",
+      start_date: "2026-9-2",
+    })).status).toBe(400);
+    expect((await call(env, "POST", "/api/events", {
+      slug: "reversed-date",
+      title: "뒤집힌 날짜",
+      start_date: "2026-09-03",
+      end_date: "2026-09-02",
+    })).status).toBe(400);
+  });
+
+  it("uses date-derived activity for implicit circle lookups", async () => {
+    await call(env, "POST", "/api/events", {
+      slug: "current-event",
+      title: "현재 행사",
+      start_date: "2026-09-01",
+      end_date: "2026-09-02",
+      status: "past",
+    });
+    await call(env, "POST", "/api/circles", { slug: "circle", name: "서클", event_slug: "current-event" });
+
+    const list = await call(env, "GET", "/api/circles");
+    expect(list.json.circles).toHaveLength(1);
+    const detail = await call(env, "GET", "/api/circles/circle");
+    expect(detail.json.circle.name).toBe("서클");
+  });
+
+  it("refreshes event status from dates in the background after listing events", async () => {
+    await call(env, "POST", "/api/events", {
+      slug: "upcoming-event",
+      title: "예정 행사",
+      start_date: "2999-09-02",
+      end_date: "2999-09-03",
+      status: "past",
+    });
+    const list = await call(env, "GET", "/api/events");
+    expect(list.json.events[0]).toMatchObject({ slug: "upcoming-event", status: "upcoming" });
   });
 
   it("upserts a circle and serializes it in list + detail", async () => {

--- a/worker/app.ts
+++ b/worker/app.ts
@@ -12,6 +12,7 @@ import {
   arrOfStr,
   intId,
   optBool,
+  dateOnly,
 } from "./validate";
 
 export type Bindings = {
@@ -45,6 +46,33 @@ type TweetRow = {
   og_image: string | null;
   og_site_name: string | null;
 };
+
+type EventStatus = "active" | "past" | "upcoming";
+type EventStatusRow = {
+  id: number;
+  start_date: string | null;
+  end_date: string | null;
+  status: string;
+};
+
+export function determineEventStatus(
+  event: Pick<EventStatusRow, "start_date" | "end_date" | "status">,
+  today = new Date().toISOString().slice(0, 10),
+): EventStatus | string {
+  if (event.start_date && event.start_date > today) return "upcoming";
+  if (event.end_date && event.end_date < today) return "past";
+  if (event.start_date || event.end_date) return "active";
+  return event.status;
+}
+
+async function refreshEventStatuses(db: D1Database, today = new Date().toISOString().slice(0, 10)) {
+  const { results } = await db.prepare("SELECT id, start_date, end_date, status FROM events").all<EventStatusRow>();
+  const updates = results
+    .map((event) => ({ event, status: determineEventStatus(event, today) }))
+    .filter(({ event, status }) => status !== event.status)
+    .map(({ event, status }) => db.prepare("UPDATE events SET status = ? WHERE id = ?").bind(status, event.id));
+  if (updates.length > 0) await db.batch(updates);
+}
 
 const PARTICIPATION_STATUSES = ["confirmed", "unlisted", "cancelled", "pending"] as const;
 
@@ -132,16 +160,27 @@ app.use("*", async (c, next) => {
 
 // ---- events ----
 app.get("/events", async (c) => {
+  c.executionCtx.waitUntil(
+    refreshEventStatuses(c.env.DB).catch((error) => {
+      console.error("event status refresh failed", error);
+    }),
+  );
   const { results } = await c.env.DB.prepare(
     "SELECT id, slug, title, alias, fare_id, date_label, start_date, end_date, venue, map_url, status FROM events ORDER BY start_date DESC"
-  ).all();
-  return c.json({ events: results });
+  ).all<EventStatusRow & Record<string, unknown>>();
+  const today = new Date().toISOString().slice(0, 10);
+  return c.json({
+    events: results.map((event) => ({ ...event, status: determineEventStatus(event, today) })),
+  });
 });
 
 app.post("/events", async (c) => {
   const body = await readJson(c);
   const slug = vSlug(body.slug, "slug");
   const title = str(body.title, "title", 200);
+  const startDate = body.start_date === undefined || body.start_date === null ? null : dateOnly(body.start_date, "start_date");
+  const endDate = body.end_date === undefined || body.end_date === null ? null : dateOnly(body.end_date, "end_date");
+  if (startDate && endDate && endDate < startDate) throw new ValidationError("end_date는 start_date보다 빠를 수 없어요");
   await c.env.DB.prepare(
     `INSERT INTO events (slug, title, alias, fare_id, date_label, start_date, end_date, venue, map_url, status)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, 'active'))`
@@ -152,8 +191,8 @@ app.post("/events", async (c) => {
       optStr(body.alias, "alias"),
       body.fare_id === undefined || body.fare_id === null ? null : intId(body.fare_id, "fare_id"),
       optStr(body.date_label, "date_label"),
-      optStr(body.start_date, "start_date"),
-      optStr(body.end_date, "end_date"),
+      startDate,
+      endDate,
       optStr(body.venue, "venue"),
       optUrl(body.map_url, "map_url"),
       optEnum(body.status, "status", ["active", "past", "upcoming"])
@@ -174,7 +213,10 @@ app.get("/circles", async (c) => {
     if (!row) return c.json({ error: "event not found", code: "not_found" }, 404);
     eventId = row.id;
   } else {
-    const row = await c.env.DB.prepare("SELECT id FROM events WHERE status = 'active' ORDER BY start_date DESC LIMIT 1").first<{ id: number }>();
+    const today = new Date().toISOString().slice(0, 10);
+    const row = await c.env.DB.prepare(
+      "SELECT id FROM events WHERE ((start_date IS NULL AND end_date IS NULL AND status = 'active') OR ((start_date IS NULL OR start_date <= ?) AND (end_date IS NULL OR end_date >= ?))) ORDER BY start_date DESC LIMIT 1",
+    ).bind(today, today).first<{ id: number }>();
     eventId = row?.id ?? null;
   }
   if (eventId === null) return c.json({ circles: [] });
@@ -224,7 +266,10 @@ app.get("/circles/:slug", async (c) => {
     const row = await c.env.DB.prepare("SELECT id FROM events WHERE slug = ?").bind(eventSlug).first<{ id: number }>();
     eventId = row?.id ?? null;
   } else {
-    const row = await c.env.DB.prepare("SELECT id FROM events WHERE status = 'active' ORDER BY start_date DESC LIMIT 1").first<{ id: number }>();
+    const today = new Date().toISOString().slice(0, 10);
+    const row = await c.env.DB.prepare(
+      "SELECT id FROM events WHERE ((start_date IS NULL AND end_date IS NULL AND status = 'active') OR ((start_date IS NULL OR start_date <= ?) AND (end_date IS NULL OR end_date >= ?))) ORDER BY start_date DESC LIMIT 1",
+    ).bind(today, today).first<{ id: number }>();
     eventId = row?.id ?? null;
   }
   if (eventId === null) return c.json({ error: "event not found", code: "not_found" }, 404);

--- a/worker/validate.ts
+++ b/worker/validate.ts
@@ -21,6 +21,17 @@ export function optStr(v: unknown, name: string, max = 2000): string | null {
   return v as string;
 }
 
+const DATE_ONLY_RE = /^\d{4}-\d{2}-\d{2}$/;
+export function dateOnly(v: unknown, name: string): string {
+  const s = str(v, name, 10);
+  if (!DATE_ONLY_RE.test(s)) fail(`${name}: YYYY-MM-DD 형식이어야 해요`);
+  const date = new Date(`${s}T00:00:00Z`);
+  if (Number.isNaN(date.getTime()) || date.toISOString().slice(0, 10) !== s) {
+    fail(`${name}: 올바른 날짜가 아니에요`);
+  }
+  return s;
+}
+
 const SLUG_RE = /^[a-z0-9][a-z0-9_-]*$/i;
 export function slug(v: unknown, name: string): string {
   const s = str(v, name, 128);


### PR DESCRIPTION
## 변경 사항
- 행사 상태를 start_date/end_date 기준으로 예정(upcoming), 진행 중(active), 종료(past)로 자동 판정
- GET /api/events 응답 후 waitUntil로 DB 상태를 비동기 갱신
- 날짜가 오래된 status여도 기본 서클 조회가 현재 날짜 범위의 행사를 선택하도록 수정
- 행사 날짜 입력을 YYYY-MM-DD 및 유효한 날짜 범위로 검증

## 검증
- npm test
- npm run typecheck
- npm run build

상태 판정은 행사 시작일과 종료일을 포함합니다.