### PR TITLE
feat: add optional 321 auth sync

### DIFF
--- a/migrations/0004_user_checks.sql
+++ b/migrations/0004_user_checks.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS user_checks (
+  user_id TEXT NOT NULL,
+  event_slug TEXT NOT NULL,
+  checks TEXT NOT NULL DEFAULT '{}',
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (user_id, event_slug)
+);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Circle } from "./types";
-import { fetchCircles, fetchEvents, pickActiveEvent, type ApiEvent } from "./api";
+import { fetchAuth, fetchCircles, fetchEvents, login, logout, pickActiveEvent, type ApiEvent, type AuthUser } from "./api";
 import { badgeColor, filterCircles, STATUS, type Status } from "./lib/circle";
 import { useChecks } from "./hooks/useChecks";
 import { useAppRoute } from "./hooks/useAppRoute";
@@ -50,7 +50,10 @@ export default function App() {
   const { route, openCircle, openEvents, backToEvent } = useAppRoute();
   const [events, setEvents] = useState<ApiEvent[]>([]);
   const [event, setEvent] = useState<ApiEvent | null>(null);
-  const [checks, toggle] = useChecks(event?.slug ?? null, event?.status === "active");
+  const [authEnabled, setAuthEnabled] = useState(false);
+  const [authLoading, setAuthLoading] = useState(true);
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [checks, toggle] = useChecks(event?.slug ?? null, event?.status === "active", !!user, authLoading);
   const [status, setStatus] = useState<Status>("all");
   const [selectedIps, setSelectedIps] = useState<string[]>([]);
   const [query, setQuery] = useState("");
@@ -64,6 +67,16 @@ export default function App() {
   const loadController = useRef<AbortController | null>(null);
   const requestedEventSlug = route.kind === "event" || route.kind === "circle" ? route.eventSlug : null;
   const routeMode = route.kind === "events" ? "events" : route.kind === "legacy-circle" ? "legacy" : "event";
+
+  const loadAuth = useCallback(() => {
+    void fetchAuth().then(({ enabled, user: currentUser }) => {
+      setAuthEnabled(enabled);
+      setUser(currentUser);
+    }).catch(() => {
+      setAuthEnabled(false);
+      setUser(null);
+    }).finally(() => setAuthLoading(false));
+  }, []);
 
   // 행사장 서클 + 통판(unlisted)을 한 데이터셋으로 다뤄 검색·필터·체크를 일관 적용
   const all = useMemo(() => [...circles, ...witchformExtra], [circles, witchformExtra]);
@@ -111,6 +124,10 @@ export default function App() {
     void load();
     return () => loadController.current?.abort();
   }, [load]);
+
+  useEffect(() => {
+    loadAuth();
+  }, [loadAuth]);
 
   useEffect(() => {
     setStatus("all");
@@ -178,7 +195,17 @@ export default function App() {
                   {eventSubtitle(event)}
                 </div>
               </div>
-              <button type="button" onClick={openEvents} className="shrink-0 rounded-full border border-line bg-card px-3 py-2 text-xs font-bold text-muted">행사 목록</button>
+               <div className="flex shrink-0 items-center gap-2">
+                 {authEnabled ? (
+                   user ? (
+                     <button type="button" onClick={logout} className="rounded-full border border-line bg-card px-3 py-2 text-xs font-bold text-muted">{user.name ?? "로그인됨"} · 로그아웃</button>
+                   ) : (
+                     <button type="button" onClick={login} className="rounded-full border border-line bg-card px-3 py-2 text-xs font-bold text-muted">로그인</button>
+                   )
+                 ) : null}
+                 <button type="button" onClick={openEvents} className="rounded-full border border-line bg-card px-3 py-2 text-xs font-bold text-muted">행사 목록</button>
+               </div>
+
             </div>
 
             <div className="flex items-center gap-2.5 h-12 bg-card border border-line rounded-[14px] px-3.5">

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,5 @@
 import type { Circle, TweetInfo } from "./types";
+import type { Checks } from "./lib/checks";
 
 export type ApiCircle = {
   id: number;
@@ -60,9 +61,46 @@ export async function fetchEvents(signal?: AbortSignal): Promise<ApiEvent[]> {
   return data.events || [];
 }
 
-export async function fetchActiveEvent(): Promise<ApiEvent | null> {
-  return pickActiveEvent(await fetchEvents());
+export type AuthUser = {
+  userId: string;
+  email: string | null;
+  name: string | null;
+  avatarUrl: string | null;
+};
+
+export async function fetchAuth(): Promise<{ enabled: boolean; user: AuthUser | null }> {
+  const res = await fetch("/api/auth/me", { credentials: "include" });
+  if (!res.ok) return { enabled: false, user: null };
+  return await res.json();
 }
+
+export function login(): void {
+  const returnTo = `${window.location.origin}${window.location.pathname}${window.location.hash}`;
+  window.location.href = `https://auth.bini59.dev/login?client_id=seoko-maps&return_to=${encodeURIComponent(returnTo)}`;
+}
+
+export function logout(): void {
+  const returnTo = `${window.location.origin}${window.location.pathname}${window.location.hash}`;
+  window.location.href = `https://auth.bini59.dev/logout?client_id=seoko-maps&return_to=${encodeURIComponent(returnTo)}`;
+}
+
+export async function fetchChecks(eventSlug: string): Promise<ChecksResponse> {
+  const res = await fetch(`/api/checks?event=${encodeURIComponent(eventSlug)}`, { credentials: "include" });
+  if (!res.ok) throw new Error("방문 체크를 불러오지 못했어요");
+  return await res.json();
+}
+
+export async function saveChecks(eventSlug: string, checks: Record<string, boolean>): Promise<void> {
+  const res = await fetch(`/api/checks?event=${encodeURIComponent(eventSlug)}`, {
+    method: "PUT",
+    credentials: "include",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ checks }),
+  });
+  if (!res.ok) throw new Error("방문 체크를 저장하지 못했어요");
+}
+
+type ChecksResponse = { checks: Record<string, boolean> };
 
 export async function fetchCircles(
   eventSlug: string,

--- a/src/hooks/useChecks.ts
+++ b/src/hooks/useChecks.ts
@@ -1,29 +1,51 @@
 import { useEffect, useState } from "react";
 import { type Checks, loadChecks, saveChecks } from "../lib/checks";
+import { fetchChecks, saveChecks as saveRemoteChecks } from "../api";
 
 /**
- * 행사별 방문 체크 상태(localStorage). eventSlug가 바뀌면 해당 행사의 저장분을
- * 다시 불러오고, 변경은 즉시 그 행사의 키에만 기록해 행사 간 상태가 섞이지 않는다.
+ * 행사별 방문 체크 상태. 비로그인은 localStorage를 사용하고, 로그인 사용자는
+ * 321_auth 세션으로 확인한 계정별 원격 저장소를 사용한다.
  */
 export function useChecks(
   eventSlug: string | null,
   migrateLegacy = false,
+  authenticated = false,
+  authLoading = false,
 ): [Checks, (id: string) => void, () => void] {
   const [checks, setChecks] = useState<Checks>({});
 
   useEffect(() => {
-    setChecks(eventSlug ? loadChecks(localStorage, eventSlug, migrateLegacy) : {});
-  }, [eventSlug, migrateLegacy]);
+    if (authLoading || !eventSlug) {
+      if (!eventSlug) setChecks({});
+      return;
+    }
+    if (!authenticated) {
+      setChecks(loadChecks(localStorage, eventSlug, migrateLegacy));
+      return;
+    }
+    const local = loadChecks(localStorage, eventSlug, migrateLegacy);
+    void fetchChecks(eventSlug).then(({ checks: remote }) => {
+      const merged = { ...local, ...remote };
+      setChecks(merged);
+      if (Object.keys(merged).some((id) => merged[id] !== remote[id])) void saveRemoteChecks(eventSlug, merged);
+    }).catch(() => setChecks(local));
+  }, [eventSlug, migrateLegacy, authenticated, authLoading]);
 
   const toggle = (id: string) =>
     setChecks((prev) => {
       const next = { ...prev, [id]: !prev[id] };
-      if (eventSlug) saveChecks(localStorage, eventSlug, next);
+      if (eventSlug) {
+        if (authenticated) void saveRemoteChecks(eventSlug, next);
+        else saveChecks(localStorage, eventSlug, next);
+      }
       return next;
     });
 
   const reset = () => {
-    if (eventSlug) saveChecks(localStorage, eventSlug, {});
+    if (eventSlug) {
+      if (authenticated) void saveRemoteChecks(eventSlug, {});
+      else saveChecks(localStorage, eventSlug, {});
+    }
     setChecks({});
   };
 

--- a/test/helpers/d1.ts
+++ b/test/helpers/d1.ts
@@ -21,9 +21,14 @@ export function makeTestDB(): D1Database {
     fileURLToPath(new URL("../../migrations/0003_ips_only.sql", import.meta.url)),
     "utf8",
   );
+  const userChecksMigration = readFileSync(
+    fileURLToPath(new URL("../../migrations/0004_user_checks.sql", import.meta.url)),
+    "utf8",
+  );
   db.exec(migration);
   db.exec(eventScopedMigration);
   db.exec(ipsMigration);
+  db.exec(userChecksMigration);
   return wrap(db);
 }
 

--- a/test/worker/api.test.ts
+++ b/test/worker/api.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { app, determineEventStatus } from "../../worker/app";
 import { makeTestDB } from "../helpers/d1";
 
@@ -34,6 +34,43 @@ describe("worker API", () => {
   it("rejects mutations without a valid bearer token", async () => {
     const r = await call(env, "POST", "/api/events", { slug: "e", title: "t" }, false);
     expect(r.status).toBe(401);
+  });
+
+  it("returns disabled auth when 321_auth is not configured", async () => {
+    const r = await call(env, "GET", "/api/auth/me");
+    expect(r.status).toBe(200);
+    expect(r.json).toEqual({ enabled: false, user: null });
+  });
+
+  it("verifies the optional 321_auth session and syncs checks per user", async () => {
+    const authFetch = vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      new Response(JSON.stringify({ userId: "user-1", email: "user@example.com", name: "User", avatarUrl: null, membership: null }), { status: 200 }),
+    );
+    const authEnv = { ...env, AUTH_ORIGIN: "https://auth.bini59.dev", AUTH_CLIENT_ID: "seoko-maps", AUTH_CLIENT_SECRET: "secret" };
+    const r = await app.fetch(
+      new Request("http://x/api/auth/me", { headers: { cookie: "sid=session" } }),
+      authEnv,
+      {} as ExecutionContext,
+    );
+    expect(r.status).toBe(200);
+    expect(await r.json()).toMatchObject({ enabled: true, user: { userId: "user-1" } });
+    expect(authFetch).toHaveBeenCalledWith(
+      "https://auth.bini59.dev/verify?client_id=seoko-maps",
+      { headers: { "x-app-secret": "secret", cookie: "sid=session" } },
+    );
+
+    const saved = await app.fetch(
+      new Request("http://x/api/checks?event=ev", { method: "PUT", headers: { "content-type": "application/json", cookie: "sid=session" }, body: JSON.stringify({ checks: { booth: true } }) }),
+      authEnv,
+      {} as ExecutionContext,
+    );
+    expect(saved.status).toBe(200);
+    const loaded = await app.fetch(
+      new Request("http://x/api/checks?event=ev", { headers: { cookie: "sid=session" } }),
+      authEnv,
+      {} as ExecutionContext,
+    );
+    expect(await loaded.json()).toEqual({ checks: { booth: true } });
   });
 
   it("creates an event and lists it", async () => {

--- a/worker/app.ts
+++ b/worker/app.ts
@@ -18,9 +18,43 @@ import {
 export type Bindings = {
   DB: D1Database;
   ADMIN_TOKEN: string;
-  /** 쉼표로 구분된 허용 origin. 없으면 모든 origin 허용(*). */
   ALLOWED_ORIGINS?: string;
+  AUTH_ORIGIN?: string;
+  AUTH_CLIENT_ID?: string;
+  AUTH_CLIENT_SECRET?: string;
 };
+
+type AuthenticatedUser = {
+  userId: string;
+  email: string | null;
+  name: string | null;
+  avatarUrl: string | null;
+  membership: { role: string; status: string; joinedAt: string } | null;
+};
+
+function authConfigured(env: Bindings): boolean {
+  return Boolean(env.AUTH_ORIGIN && env.AUTH_CLIENT_ID && env.AUTH_CLIENT_SECRET);
+}
+
+async function verifyAuth(c: Context<{ Bindings: Bindings }>): Promise<AuthenticatedUser | null> {
+  if (!authConfigured(c.env)) return null;
+  const cookie = c.req.header("cookie");
+  if (!cookie) return null;
+  const url = new URL("/verify", c.env.AUTH_ORIGIN);
+  url.searchParams.set("client_id", c.env.AUTH_CLIENT_ID!);
+  const response = await fetch(url.toString(), {
+    headers: { "x-app-secret": c.env.AUTH_CLIENT_SECRET!, cookie },
+  });
+  if (response.status === 401 || response.status === 403) return null;
+  if (!response.ok) throw new Error("auth verification failed");
+  return await response.json<AuthenticatedUser>();
+}
+
+async function requireAuth(c: Context<{ Bindings: Bindings }>): Promise<AuthenticatedUser | Response> {
+  if (!authConfigured(c.env)) return c.json({ error: "auth is not configured", code: "auth_unavailable" }, 503);
+  const user = await verifyAuth(c);
+  return user ?? c.json({ error: "unauthorized", code: "unauthorized" }, 401);
+}
 
 type CircleRow = {
   circle_id: number;
@@ -136,6 +170,7 @@ app.onError((err, c) => {
 });
 
 app.use("*", cors({
+  credentials: true,
   origin: (origin, c) => {
     const allowed = (c.env.ALLOWED_ORIGINS || "")
       .split(",")
@@ -148,7 +183,7 @@ app.use("*", cors({
 
 // require bearer token for mutating routes only
 app.use("*", async (c, next) => {
-  if (["POST", "PATCH", "PUT", "DELETE"].includes(c.req.method)) {
+  if (["POST", "PATCH", "PUT", "DELETE"].includes(c.req.method) && c.req.path !== "/api/checks") {
     const auth = c.req.header("authorization") || "";
     const token = auth.startsWith("Bearer ") ? auth.slice(7) : "";
     if (!c.env.ADMIN_TOKEN || token !== c.env.ADMIN_TOKEN) {
@@ -159,6 +194,42 @@ app.use("*", async (c, next) => {
 });
 
 // ---- events ----
+app.get("/auth/me", async (c) => {
+  const user = await verifyAuth(c);
+  return c.json({ enabled: authConfigured(c.env), user });
+});
+
+app.get("/checks", async (c) => {
+  const eventSlug = vSlug(c.req.query("event"), "event");
+  const user = await requireAuth(c);
+  if (user instanceof Response) return user;
+  const row = await c.env.DB.prepare("SELECT checks FROM user_checks WHERE user_id = ? AND event_slug = ?")
+    .bind(user.userId, eventSlug)
+    .first<{ checks: string }>();
+  return c.json({ checks: row ? JSON.parse(row.checks) : {} });
+});
+
+app.put("/checks", async (c) => {
+  const eventSlug = vSlug(c.req.query("event"), "event");
+  const user = await requireAuth(c);
+  if (user instanceof Response) return user;
+  const body = await readJson(c);
+  const checks = body.checks;
+  if (typeof checks !== "object" || checks === null || Array.isArray(checks)) {
+    throw new ValidationError("checks는 JSON 객체여야 해요");
+  }
+  const checkMap = checks as Record<string, unknown>;
+  const keys = Object.keys(checkMap);
+  if (keys.length > 3000 || keys.some((key) => key.length > 200)) {
+    throw new ValidationError("방문 체크 항목이 너무 많거나 길어요");
+  }
+  const normalized = Object.fromEntries(keys.map((key) => [key, checkMap[key] === true]));
+  await c.env.DB.prepare(
+    "INSERT INTO user_checks (user_id, event_slug, checks, updated_at) VALUES (?, ?, ?, datetime('now')) ON CONFLICT(user_id, event_slug) DO UPDATE SET checks = excluded.checks, updated_at = excluded.updated_at",
+  ).bind(user.userId, eventSlug, JSON.stringify(normalized)).run();
+  return c.json({ checks: normalized });
+});
+
 app.get("/events", async (c) => {
   c.executionCtx.waitUntil(
     refreshEventStatuses(c.env.DB).catch((error) => {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -20,5 +20,9 @@
       "database_name": "gbc-seoko-db",
       "database_id": "b45883c7-c39b-4f96-9640-c41b41792511"
     }
-  ]
+  ],
+  "vars": {
+    "AUTH_ORIGIN": "https://auth.bini59.dev",
+    "AUTH_CLIENT_ID": "seoko-maps"
+  }
 }


### PR DESCRIPTION
## Summary
- Add optional 321_auth login for seoko-maps.bini59.dev
- Keep guest checklist data in localStorage
- Sync authenticated users' checklist data to D1 per account and event
- Add auth session verification, payload validation, and CORS credentials support

## Verification
- npm test -- --run
- npm run typecheck
- npm run build

## Deployment
Set the client secret with:
`wrangler secret put AUTH_CLIENT_SECRET`