### PR TITLE
feat: 데스크톱 뷰 — 사이드바 + 콘텐츠 2컬럼 쉘 (#28)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -120,10 +120,11 @@ export default function App() {
   const statusChip = (active: boolean) =>
     "inline-flex items-center h-[32px] px-3 rounded-[8px] text-[13px] font-medium cursor-pointer whitespace-nowrap border " +
     (active ? "bg-ink text-bg border-ink" : "bg-card text-muted border-line");
-  const gridCls = "grid gap-3 md:grid-cols-2 xl:grid-cols-3";
   const genreChip = (active: boolean) =>
     "inline-flex items-center h-7 px-2.5 rounded-full text-[12px] font-medium cursor-pointer whitespace-nowrap border " +
     (active ? "bg-accent/10 text-accent border-accent/30" : "bg-card text-muted border-line");
+  // 상세 패널이 열리면 xl에서도 2열 유지(목록 폭이 줄어듦)
+  const gridCls = "grid gap-3 md:grid-cols-2 " + (detail ? "" : "xl:grid-cols-3");
 
   return (
     // 쉘: 모바일은 단일 컬럼(560px), md 이상은 사이드바 + 콘텐츠 2컬럼. 컴포넌트는 공유하고 레이아웃만 분기.
@@ -138,60 +139,33 @@ export default function App() {
         authEnabled={authEnabled}
         user={user}
       />
-      <div className={"w-full max-w-[560px] mx-auto border-x border-line md:max-w-none md:mx-0 md:border-x-0 md:min-h-screen " + (route.kind === "events" ? "" : "flex-1")}>
-      {route.kind === "events" ? (
-        <main className="px-5 pt-7 pb-2 md:px-8 md:py-10">
-          <h1 className="text-[26px] font-extrabold text-ink">행사 선택</h1>
-          <p className="mt-2 text-sm text-muted">방문할 행사를 골라 관심 서클을 확인하세요.</p>
-          {loadError ? <div role="alert" className="mt-8 text-sm text-[#e0455c]">{loadError}</div> : null}
-          {!loading && !loadError && events.length === 0 ? <div className="py-14 text-center text-sm text-faint">등록된 행사가 없어요</div> : null}
-        </main>
-      ) : (
-        <div className="md:flex md:items-start">
-        {/* 목록 — 모바일에서 상세가 열리면 숨김, 데스크톱은 유지 */}
-        <div className={"min-w-0 flex-1 pb-7 " + (detail ? "hidden md:block" : "")}>
-          {/* sticky 헤더(모바일) / topbar(데스크톱) */}
-          <div className="sticky top-0 z-10 bg-bg/95 backdrop-blur px-5 pt-[22px] pb-3 border-b border-line md:px-8 md:pt-4">
-            <div className="mb-4 flex items-start justify-between gap-3 md:mb-3 md:items-center md:gap-6">
-              <div className="min-w-0">
-                <div className="text-[22px] font-extrabold -tracking-[0.02em] text-ink leading-none md:text-[19px]">
-                {event?.title ?? "동인행사 체크리스트"}
+      <main className={"w-full max-w-[560px] mx-auto border-x border-line md:max-w-none md:mx-0 md:border-x-0 md:min-h-screen " + (route.kind === "events" ? "" : "flex-1")}>
+        {route.kind === "events" ? (
+          <div className="px-5 pt-7 pb-2 md:px-8 md:py-10">
+            <h1 className="text-[26px] font-extrabold text-ink">행사 선택</h1>
+            <p className="mt-2 text-sm text-muted">방문할 행사를 골라 관심 서클을 확인하세요.</p>
+            {loadError ? <div role="alert" className="mt-8 text-sm text-[#e0455c]">{loadError}</div> : null}
+            {!loading && !loadError && events.length === 0 ? <div className="py-14 text-center text-sm text-faint">등록된 행사가 없어요</div> : null}
+          </div>
+        ) : (
+          <div className="xl:flex xl:items-start">
+            {/* 목록 — 상세가 열리면 xl 미만은 숨김(전체 화면 상세), xl 이상은 유지 */}
+            <div className={"min-w-0 flex-1 pb-7 " + (detail ? "hidden xl:block" : "")}>
+              {/* sticky 헤더(모바일) / topbar(데스크톱) */}
+              <div className="sticky top-0 z-10 bg-bg/95 backdrop-blur px-5 pt-[22px] pb-3 border-b border-line md:px-8 md:pt-4">
+                <div className="mb-4 flex items-start justify-between gap-3 md:mb-3 md:items-center md:gap-6">
+                  <div className="min-w-0">
+                    <div className="text-[22px] font-extrabold -tracking-[0.02em] text-ink leading-none md:text-[19px]">
+                    {event?.title ?? "동인행사 체크리스트"}
+                    </div>
+                    <div className="text-xs font-semibold text-faint mt-[5px] truncate">
+                      {eventSubtitle(event)}
+                    </div>
+                  </div>
+                  <button type="button" onClick={openEvents} className="shrink-0 rounded-full border border-line bg-card px-3 py-2 text-xs font-bold text-muted md:hidden">행사 목록</button>
                 </div>
-                <div className="text-xs font-semibold text-faint mt-[5px] truncate">
-                  {eventSubtitle(event)}
-                </div>
-              </div>
-              <button type="button" onClick={openEvents} className="shrink-0 rounded-full border border-line bg-card px-3 py-2 text-xs font-bold text-muted md:hidden">행사 목록</button>
-            </div>
 
-            <div className="flex items-center gap-2.5 h-12 bg-card border border-line rounded-[14px] px-3.5 md:h-10 md:max-w-[520px]">
-              <svg
-                viewBox="0 0 24 24"
-                width="20"
-                height="20"
-                fill="none"
-                stroke="#9aa0aa"
-                strokeWidth="2"
-                strokeLinecap="round"
-              >
-                <circle cx="11" cy="11" r="7" />
-                <path d="M21 21l-4-4" />
-              </svg>
-              <input
-                type="search"
-                value={query}
-                onChange={(e) => setQuery(e.target.value)}
-                placeholder="서클 · 부스 · 장르 검색"
-                aria-label="서클·부스·장르 검색"
-                className="flex-1 min-w-0 border-0 outline-none bg-transparent text-[16px] text-ink placeholder:text-faint"
-              />
-              {query ? (
-                <button
-                  onClick={() => setQuery("")}
-                  title="검색 초기화"
-                  aria-label="검색 초기화"
-                  className="flex items-center"
-                >
+                <div className="flex items-center gap-2.5 h-12 bg-card border border-line rounded-[14px] px-3.5 md:h-10 md:max-w-[520px]">
                   <svg
                     viewBox="0 0 24 24"
                     width="20"
@@ -201,164 +175,191 @@ export default function App() {
                     strokeWidth="2"
                     strokeLinecap="round"
                   >
-                    <path d="M6 6l12 12M18 6L6 18" />
+                    <circle cx="11" cy="11" r="7" />
+                    <path d="M21 21l-4-4" />
                   </svg>
-                </button>
-              ) : event?.map_url ? (
-                <a
-                  href={event.map_url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  title="전체 부스배치도"
-                  aria-label="전체 부스배치도 (새 창)"
-                  className="flex items-center"
-                >
-                  <svg
-                    viewBox="0 0 24 24"
-                    width="20"
-                    height="20"
-                    fill="none"
-                    stroke="#9aa0aa"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  >
-                    <path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0z" />
-                    <circle cx="12" cy="10" r="3" />
-                  </svg>
-                </a>
-              ) : null}
-            </div>
-
-            <div className="flex gap-2 mt-3.5">
-              {STATUS.map((s) => (
-                <button
-                  key={s.k}
-                  onClick={() => setStatus(s.k)}
-                  aria-pressed={status === s.k}
-                  className={statusChip(status === s.k)}
-                >
-                  {s.label}
-                </button>
-              ))}
-            </div>
-          </div>
-
-          {/* 장르 칩 (가로 스크롤) */}
-          <div className="flex gap-2 overflow-x-auto no-scrollbar px-5 pt-1 pb-0.5 md:flex-wrap md:px-8 md:pt-4">
-            <button
-              onClick={() => setSelectedIps([])}
-              aria-pressed={selectedIps.length === 0}
-              className={genreChip(selectedIps.length === 0)}
-            >
-              전체 장르
-            </button>
-            {Array.from(new Set(all.flatMap((circle) => circle.ips ?? []).filter(Boolean))).sort().map((g) => (
-              <button
-                key={g}
-                onClick={() =>
-                  setSelectedIps((prev) =>
-                    prev.includes(g) ? prev.filter((x) => x !== g) : [...prev, g],
-                  )
-                }
-                aria-pressed={selectedIps.includes(g)}
-                className={genreChip(selectedIps.includes(g))}
-              >
-                {g}
-              </button>
-            ))}
-          </div>
-
-          {/* 진행 표시 */}
-          <div className="flex items-center justify-between px-[22px] pt-3.5 pb-2 md:px-8">
-            <div className="text-[12.5px] font-bold text-faint">참가 서클 {filtered.length}곳</div>
-            <div className="text-[12.5px] font-bold text-accent">
-              방문 {doneCount}/{all.length}
-            </div>
-          </div>
-
-          {/* 카드 목록 — 데스크톱은 2~3열 그리드 */}
-          <div className="px-5 md:px-8">
-            {loadError && (
-              <div className="text-center py-14" role="alert">
-                <div className="text-[#e0455c] text-sm font-semibold">{loadError}</div>
-                <button
-                  onClick={() => void load()}
-                  disabled={loading}
-                  className="mt-3 inline-flex items-center h-9 px-4 rounded-full bg-ink text-bg text-[13px] font-bold cursor-pointer border-0 disabled:opacity-60"
-                >
-                  {loading ? "다시 시도 중…" : "다시 시도"}
-                </button>
-              </div>
-            )}
-            {!loadError && loading && circles.length === 0 && (
-              <div className="text-center py-14 text-[#b0b4bc] text-sm font-semibold">
-                불러오는 중...
-              </div>
-            )}
-            {!loadError && (
-              <div className={gridCls}>
-                {boothList.map((c) => (
-                  <Card
-                    key={c.id}
-                    item={c}
-                    checked={!!checks[c.id]}
-                    onToggle={() => handleToggle(c.id)}
-                    onOpen={() => event && openCircle(event.slug, c.id)}
-                    color={badgeColor(c.id, all)}
+                  <input
+                    type="search"
+                    value={query}
+                    onChange={(e) => setQuery(e.target.value)}
+                    placeholder="서클 · 부스 · 장르 검색"
+                    aria-label="서클·부스·장르 검색"
+                    className="flex-1 min-w-0 border-0 outline-none bg-transparent text-[16px] text-ink placeholder:text-faint"
                   />
-                ))}
-              </div>
-            )}
-
-            {/* 통판(윗치폼) 섹션 — 행사장 부스 없이 온라인 주문 */}
-            {!loadError && tsuhanList.length > 0 && (
-              <>
-                <div className="flex items-center gap-2 mt-7 mb-3.5">
-                  <span className="text-[12.5px] font-extrabold tracking-[0.04em] text-faint">
-                    윗치폼 통판
-                  </span>
-                  <span className="text-[11px] font-bold text-accent">{tsuhanList.length}</span>
-                  <div className="flex-1 h-px bg-line" />
+                  {query ? (
+                    <button
+                      onClick={() => setQuery("")}
+                      title="검색 초기화"
+                      aria-label="검색 초기화"
+                      className="flex items-center"
+                    >
+                      <svg
+                        viewBox="0 0 24 24"
+                        width="20"
+                        height="20"
+                        fill="none"
+                        stroke="#9aa0aa"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                      >
+                        <path d="M6 6l12 12M18 6L6 18" />
+                      </svg>
+                    </button>
+                  ) : event?.map_url ? (
+                    <a
+                      href={event.map_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      title="전체 부스배치도"
+                      aria-label="전체 부스배치도 (새 창)"
+                      className="flex items-center"
+                    >
+                      <svg
+                        viewBox="0 0 24 24"
+                        width="20"
+                        height="20"
+                        fill="none"
+                        stroke="#9aa0aa"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      >
+                        <path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0z" />
+                        <circle cx="12" cy="10" r="3" />
+                      </svg>
+                    </a>
+                  ) : null}
                 </div>
-                <div className={gridCls}>
-                  {tsuhanList.map((c) => (
-                    <Card
-                      key={c.id}
-                      item={c}
-                      checked={!!checks[c.id]}
-                      onToggle={() => handleToggle(c.id)}
-                      onOpen={() => event && openCircle(event.slug, c.id)}
-                      color={badgeColor(c.id, all)}
-                    />
+
+                <div className="flex gap-2 mt-3.5">
+                  {STATUS.map((s) => (
+                    <button
+                      key={s.k}
+                      onClick={() => setStatus(s.k)}
+                      aria-pressed={status === s.k}
+                      className={statusChip(status === s.k)}
+                    >
+                      {s.label}
+                    </button>
                   ))}
                 </div>
-              </>
-            )}
-
-            {!loadError && !loading && filtered.length === 0 && (
-              <div className="text-center py-14 text-[#b0b4bc] text-sm font-semibold">
-                조건에 맞는 서클이 없어요
               </div>
+
+              {/* 장르 칩 (가로 스크롤) */}
+              <div className="flex gap-2 overflow-x-auto no-scrollbar px-5 pt-1 pb-0.5 md:flex-wrap md:px-8 md:pt-4">
+                <button
+                  onClick={() => setSelectedIps([])}
+                  aria-pressed={selectedIps.length === 0}
+                  className={genreChip(selectedIps.length === 0)}
+                >
+                  전체 장르
+                </button>
+                {Array.from(new Set(all.flatMap((circle) => circle.ips ?? []).filter(Boolean))).sort().map((g) => (
+                  <button
+                    key={g}
+                    onClick={() =>
+                      setSelectedIps((prev) =>
+                        prev.includes(g) ? prev.filter((x) => x !== g) : [...prev, g],
+                      )
+                    }
+                    aria-pressed={selectedIps.includes(g)}
+                    className={genreChip(selectedIps.includes(g))}
+                  >
+                    {g}
+                  </button>
+                ))}
+              </div>
+
+              {/* 진행 표시 */}
+              <div className="flex items-center justify-between px-[22px] pt-3.5 pb-2 md:px-8">
+                <div className="text-[12.5px] font-bold text-faint">참가 서클 {filtered.length}곳</div>
+                <div className="text-[12.5px] font-bold text-accent">
+                  방문 {doneCount}/{all.length}
+                </div>
+              </div>
+
+              {/* 카드 목록 — 데스크톱은 2~3열 그리드 */}
+              <div className="px-5 md:px-8">
+                {loadError && (
+                  <div className="text-center py-14" role="alert">
+                    <div className="text-[#e0455c] text-sm font-semibold">{loadError}</div>
+                    <button
+                      onClick={() => void load()}
+                      disabled={loading}
+                      className="mt-3 inline-flex items-center h-9 px-4 rounded-full bg-ink text-bg text-[13px] font-bold cursor-pointer border-0 disabled:opacity-60"
+                    >
+                      {loading ? "다시 시도 중…" : "다시 시도"}
+                    </button>
+                  </div>
+                )}
+                {!loadError && loading && circles.length === 0 && (
+                  <div className="text-center py-14 text-[#b0b4bc] text-sm font-semibold">
+                    불러오는 중...
+                  </div>
+                )}
+                {!loadError && (
+                  <div className={gridCls}>
+                    {boothList.map((c) => (
+                      <Card
+                        key={c.id}
+                        item={c}
+                        checked={!!checks[c.id]}
+                        onToggle={() => handleToggle(c.id)}
+                        onOpen={() => event && openCircle(event.slug, c.id)}
+                        color={badgeColor(c.id, all)}
+                      />
+                    ))}
+                  </div>
+                )}
+
+                {/* 통판(윗치폼) 섹션 — 행사장 부스 없이 온라인 주문 */}
+                {!loadError && tsuhanList.length > 0 && (
+                  <>
+                    <div className="flex items-center gap-2 mt-7 mb-3.5">
+                      <span className="text-[12.5px] font-extrabold tracking-[0.04em] text-faint">
+                        윗치폼 통판
+                      </span>
+                      <span className="text-[11px] font-bold text-accent">{tsuhanList.length}</span>
+                      <div className="flex-1 h-px bg-line" />
+                    </div>
+                    <div className={gridCls}>
+                      {tsuhanList.map((c) => (
+                        <Card
+                          key={c.id}
+                          item={c}
+                          checked={!!checks[c.id]}
+                          onToggle={() => handleToggle(c.id)}
+                          onOpen={() => event && openCircle(event.slug, c.id)}
+                          color={badgeColor(c.id, all)}
+                        />
+                      ))}
+                    </div>
+                  </>
+                )}
+
+                {!loadError && !loading && filtered.length === 0 && (
+                  <div className="text-center py-14 text-[#b0b4bc] text-sm font-semibold">
+                    조건에 맞는 서클이 없어요
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* 서클 상세 — xl 미만은 전체 화면, xl 이상은 우측 패널(목록 유지) */}
+            {detail && (
+              <section aria-label="서클 상세" className="min-w-0 xl:w-[400px] xl:shrink-0 xl:sticky xl:top-0 xl:h-screen xl:overflow-y-auto xl:border-l xl:border-line">
+                <Detail
+                  item={detail}
+                  checked={!!checks[detail.id]}
+                  onToggle={() => handleToggle(detail.id)}
+                  onBack={() => event && backToEvent(event.slug)}
+                  color={badgeColor(detail.id, all)}
+                />
+              </section>
             )}
           </div>
-        </div>
-
-        {/* 서클 상세 — 모바일은 전체 화면, 데스크톱은 우측 패널(목록 유지) */}
-        {detail && (
-          <aside className="min-w-0 md:w-[400px] md:shrink-0 md:sticky md:top-0 md:h-screen md:overflow-y-auto md:border-l md:border-line">
-            <Detail
-              item={detail}
-              checked={!!checks[detail.id]}
-              onToggle={() => handleToggle(detail.id)}
-              onBack={() => event && backToEvent(event.slug)}
-              color={badgeColor(detail.id, all)}
-            />
-          </aside>
         )}
-        </div>
-      )}
-      </div>
+      </main>
     </div>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,49 +1,13 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Circle } from "./types";
-import { fetchAuth, fetchCircles, fetchEvents, login, logout, pickActiveEvent, type ApiEvent, type AuthUser } from "./api";
+import { fetchAuth, fetchCircles, fetchEvents, pickActiveEvent, type ApiEvent, type AuthUser } from "./api";
 import { badgeColor, filterCircles, STATUS, type Status } from "./lib/circle";
 import { useChecks } from "./hooks/useChecks";
 import { useAppRoute } from "./hooks/useAppRoute";
 import { Card } from "./components/Card";
 import { Detail } from "./components/Detail";
-
-/** 행사 부제: 별칭·장소·기간 중 존재하는 것만 · 로 잇는다. */
-function eventSubtitle(event: ApiEvent | null): string {
-  if (!event) return "행사 정보를 불러오는 중…";
-  const parts = [event.alias || event.title, event.venue, event.date_label].filter(Boolean);
-  return parts.length ? parts.join(" · ") : event.title;
-}
-
-const EVENT_SECTIONS = [
-  { status: "active", label: "진행 중" },
-  { status: "upcoming", label: "예정" },
-  { status: "past", label: "지난 행사" },
-] as const;
-
-function EventList({ events }: { events: ApiEvent[] }) {
-  return EVENT_SECTIONS.map(({ status, label }) => {
-    const matches = events
-      .filter((event) => event.status === status)
-      .sort((a, b) => {
-        const comparison = (a.start_date ?? "").localeCompare(b.start_date ?? "");
-        return status === "past" ? -comparison : comparison;
-      });
-    if (matches.length === 0) return null;
-    return (
-      <section key={status} className="mt-6">
-        <h2 className="mb-2 text-xs font-extrabold tracking-[0.04em] text-faint">{label}</h2>
-        <div className="flex flex-col gap-3">
-          {matches.map((candidate) => (
-            <a key={candidate.slug} href={`#/events/${encodeURIComponent(candidate.slug)}`} className="block rounded-[18px] border border-line bg-card p-4 no-underline">
-              <div className="text-[17px] font-extrabold text-ink">{candidate.title}</div>
-              <div className="mt-1 text-xs font-semibold text-faint">{eventSubtitle(candidate)}</div>
-            </a>
-          ))}
-        </div>
-      </section>
-    );
-  });
-}
+import { Sidebar } from "./components/Sidebar";
+import { eventSubtitle } from "./lib/event";
 
 /* ---------- 앱 ---------- */
 export default function App() {
@@ -156,59 +120,51 @@ export default function App() {
   const statusChip = (active: boolean) =>
     "inline-flex items-center h-[32px] px-3 rounded-[8px] text-[13px] font-medium cursor-pointer whitespace-nowrap border " +
     (active ? "bg-ink text-bg border-ink" : "bg-card text-muted border-line");
+  const gridCls = "grid gap-3 md:grid-cols-2 xl:grid-cols-3";
   const genreChip = (active: boolean) =>
     "inline-flex items-center h-7 px-2.5 rounded-full text-[12px] font-medium cursor-pointer whitespace-nowrap border " +
     (active ? "bg-accent/10 text-accent border-accent/30" : "bg-card text-muted border-line");
 
   return (
-    <div className="min-h-screen bg-bg max-w-[560px] mx-auto border-x border-line">
+    // 쉘: 모바일은 단일 컬럼(560px), md 이상은 사이드바 + 콘텐츠 2컬럼. 컴포넌트는 공유하고 레이아웃만 분기.
+    <div className="min-h-screen bg-bg flex flex-col md:grid md:grid-cols-[260px_minmax(0,1fr)]">
       <div role="status" aria-live="polite" className="sr-only">
         {announce}
       </div>
+      <Sidebar
+        events={events}
+        currentSlug={event?.slug ?? null}
+        showOnMobile={route.kind === "events"}
+        authEnabled={authEnabled}
+        user={user}
+      />
+      <div className={"w-full max-w-[560px] mx-auto border-x border-line md:max-w-none md:mx-0 md:border-x-0 md:min-h-screen " + (route.kind === "events" ? "" : "flex-1")}>
       {route.kind === "events" ? (
-        <main className="px-5 py-7">
-          <div className="text-sm font-extrabold text-accent">동인행사 체크리스트</div>
-          <h1 className="mt-1 text-[26px] font-extrabold text-ink">행사 선택</h1>
+        <main className="px-5 pt-7 pb-2 md:px-8 md:py-10">
+          <h1 className="text-[26px] font-extrabold text-ink">행사 선택</h1>
           <p className="mt-2 text-sm text-muted">방문할 행사를 골라 관심 서클을 확인하세요.</p>
           {loadError ? <div role="alert" className="mt-8 text-sm text-[#e0455c]">{loadError}</div> : null}
-          <EventList events={events} />
           {!loading && !loadError && events.length === 0 ? <div className="py-14 text-center text-sm text-faint">등록된 행사가 없어요</div> : null}
         </main>
-      ) : detail ? (
-        <Detail
-          item={detail}
-          checked={!!checks[detail.id]}
-          onToggle={() => handleToggle(detail.id)}
-          onBack={() => event && backToEvent(event.slug)}
-          color={badgeColor(detail.id, all)}
-        />
       ) : (
-        <div className="pb-7">
-          {/* sticky 헤더 */}
-          <div className="sticky top-0 z-10 bg-bg/95 backdrop-blur px-5 pt-[22px] pb-3 border-b border-line">
-            <div className="mb-4 flex items-start justify-between gap-3">
-              <div>
-                <div className="text-[22px] font-extrabold -tracking-[0.02em] text-ink leading-none">
+        <div className="md:flex md:items-start">
+        {/* 목록 — 모바일에서 상세가 열리면 숨김, 데스크톱은 유지 */}
+        <div className={"min-w-0 flex-1 pb-7 " + (detail ? "hidden md:block" : "")}>
+          {/* sticky 헤더(모바일) / topbar(데스크톱) */}
+          <div className="sticky top-0 z-10 bg-bg/95 backdrop-blur px-5 pt-[22px] pb-3 border-b border-line md:px-8 md:pt-4">
+            <div className="mb-4 flex items-start justify-between gap-3 md:mb-3 md:items-center md:gap-6">
+              <div className="min-w-0">
+                <div className="text-[22px] font-extrabold -tracking-[0.02em] text-ink leading-none md:text-[19px]">
                 {event?.title ?? "동인행사 체크리스트"}
                 </div>
-                <div className="text-xs font-semibold text-faint mt-[5px]">
+                <div className="text-xs font-semibold text-faint mt-[5px] truncate">
                   {eventSubtitle(event)}
                 </div>
               </div>
-               <div className="flex shrink-0 items-center gap-2">
-                 {authEnabled ? (
-                   user ? (
-                     <button type="button" onClick={logout} className="rounded-full border border-line bg-card px-3 py-2 text-xs font-bold text-muted">{user.name ?? "로그인됨"} · 로그아웃</button>
-                   ) : (
-                     <button type="button" onClick={login} className="rounded-full border border-line bg-card px-3 py-2 text-xs font-bold text-muted">로그인</button>
-                   )
-                 ) : null}
-                 <button type="button" onClick={openEvents} className="rounded-full border border-line bg-card px-3 py-2 text-xs font-bold text-muted">행사 목록</button>
-               </div>
-
+              <button type="button" onClick={openEvents} className="shrink-0 rounded-full border border-line bg-card px-3 py-2 text-xs font-bold text-muted md:hidden">행사 목록</button>
             </div>
 
-            <div className="flex items-center gap-2.5 h-12 bg-card border border-line rounded-[14px] px-3.5">
+            <div className="flex items-center gap-2.5 h-12 bg-card border border-line rounded-[14px] px-3.5 md:h-10 md:max-w-[520px]">
               <svg
                 viewBox="0 0 24 24"
                 width="20"
@@ -289,7 +245,7 @@ export default function App() {
           </div>
 
           {/* 장르 칩 (가로 스크롤) */}
-          <div className="flex gap-2 overflow-x-auto no-scrollbar px-5 pt-1 pb-0.5">
+          <div className="flex gap-2 overflow-x-auto no-scrollbar px-5 pt-1 pb-0.5 md:flex-wrap md:px-8 md:pt-4">
             <button
               onClick={() => setSelectedIps([])}
               aria-pressed={selectedIps.length === 0}
@@ -314,15 +270,15 @@ export default function App() {
           </div>
 
           {/* 진행 표시 */}
-          <div className="flex items-center justify-between px-[22px] pt-3.5 pb-2">
+          <div className="flex items-center justify-between px-[22px] pt-3.5 pb-2 md:px-8">
             <div className="text-[12.5px] font-bold text-faint">참가 서클 {filtered.length}곳</div>
             <div className="text-[12.5px] font-bold text-accent">
               방문 {doneCount}/{all.length}
             </div>
           </div>
 
-          {/* 카드 목록 */}
-          <div className="flex flex-col gap-3 px-5">
+          {/* 카드 목록 — 데스크톱은 2~3열 그리드 */}
+          <div className="px-5 md:px-8">
             {loadError && (
               <div className="text-center py-14" role="alert">
                 <div className="text-[#e0455c] text-sm font-semibold">{loadError}</div>
@@ -340,29 +296,9 @@ export default function App() {
                 불러오는 중...
               </div>
             )}
-            {!loadError &&
-              boothList.map((c) => (
-                <Card
-                  key={c.id}
-                  item={c}
-                  checked={!!checks[c.id]}
-                  onToggle={() => handleToggle(c.id)}
-                  onOpen={() => event && openCircle(event.slug, c.id)}
-                  color={badgeColor(c.id, all)}
-                />
-              ))}
-
-            {/* 통판(윗치폼) 섹션 — 행사장 부스 없이 온라인 주문 */}
-            {!loadError && tsuhanList.length > 0 && (
-              <>
-                <div className="flex items-center gap-2 mt-4 mb-0.5">
-                  <span className="text-[12.5px] font-extrabold tracking-[0.04em] text-faint">
-                    윗치폼 통판
-                  </span>
-                  <span className="text-[11px] font-bold text-accent">{tsuhanList.length}</span>
-                  <div className="flex-1 h-px bg-line" />
-                </div>
-                {tsuhanList.map((c) => (
+            {!loadError && (
+              <div className={gridCls}>
+                {boothList.map((c) => (
                   <Card
                     key={c.id}
                     item={c}
@@ -372,6 +308,31 @@ export default function App() {
                     color={badgeColor(c.id, all)}
                   />
                 ))}
+              </div>
+            )}
+
+            {/* 통판(윗치폼) 섹션 — 행사장 부스 없이 온라인 주문 */}
+            {!loadError && tsuhanList.length > 0 && (
+              <>
+                <div className="flex items-center gap-2 mt-7 mb-3.5">
+                  <span className="text-[12.5px] font-extrabold tracking-[0.04em] text-faint">
+                    윗치폼 통판
+                  </span>
+                  <span className="text-[11px] font-bold text-accent">{tsuhanList.length}</span>
+                  <div className="flex-1 h-px bg-line" />
+                </div>
+                <div className={gridCls}>
+                  {tsuhanList.map((c) => (
+                    <Card
+                      key={c.id}
+                      item={c}
+                      checked={!!checks[c.id]}
+                      onToggle={() => handleToggle(c.id)}
+                      onOpen={() => event && openCircle(event.slug, c.id)}
+                      color={badgeColor(c.id, all)}
+                    />
+                  ))}
+                </div>
               </>
             )}
 
@@ -382,7 +343,22 @@ export default function App() {
             )}
           </div>
         </div>
+
+        {/* 서클 상세 — 모바일은 전체 화면, 데스크톱은 우측 패널(목록 유지) */}
+        {detail && (
+          <aside className="min-w-0 md:w-[400px] md:shrink-0 md:sticky md:top-0 md:h-screen md:overflow-y-auto md:border-l md:border-line">
+            <Detail
+              item={detail}
+              checked={!!checks[detail.id]}
+              onToggle={() => handleToggle(detail.id)}
+              onBack={() => event && backToEvent(event.slug)}
+              color={badgeColor(detail.id, all)}
+            />
+          </aside>
+        )}
+        </div>
       )}
+      </div>
     </div>
   );
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,0 +1,92 @@
+import { login, logout, type ApiEvent, type AuthUser } from "../api";
+import { eventSubtitle } from "../lib/event";
+
+const EVENT_SECTIONS = [
+  { status: "active", label: "진행 중" },
+  { status: "upcoming", label: "예정" },
+  { status: "past", label: "지난 행사" },
+] as const;
+
+function EventList({ events, currentSlug }: { events: ApiEvent[]; currentSlug: string | null }) {
+  return EVENT_SECTIONS.map(({ status, label }) => {
+    const matches = events
+      .filter((event) => event.status === status)
+      .sort((a, b) => {
+        const comparison = (a.start_date ?? "").localeCompare(b.start_date ?? "");
+        return status === "past" ? -comparison : comparison;
+      });
+    if (matches.length === 0) return null;
+    return (
+      <section key={status} className="mt-6 md:mt-5">
+        <h2 className="mb-2 text-xs font-extrabold tracking-[0.04em] text-faint">{label}</h2>
+        <div className="flex flex-col gap-3 md:gap-1">
+          {matches.map((candidate) => {
+            const current = candidate.slug === currentSlug;
+            return (
+              <a
+                key={candidate.slug}
+                href={`#/events/${encodeURIComponent(candidate.slug)}`}
+                aria-current={current ? "page" : undefined}
+                className={
+                  "block rounded-[18px] border p-4 no-underline md:rounded-[10px] md:border-transparent md:px-3 md:py-2 " +
+                  (current ? "border-accent/40 bg-accent/10" : "border-line bg-card md:bg-transparent md:hover:bg-chip")
+                }
+              >
+                <div className={"text-[17px] font-extrabold md:text-sm " + (current ? "text-accent" : "text-ink")}>{candidate.title}</div>
+                <div className="mt-1 text-xs font-semibold text-faint md:mt-0.5 md:text-[11px]">{eventSubtitle(candidate)}</div>
+              </a>
+            );
+          })}
+        </div>
+      </section>
+    );
+  });
+}
+
+/**
+ * 데스크톱(md+) 좌측 사이드바: 브랜드 · 행사 목록 · 하단 동기화(로그인) 진입점.
+ * 모바일에서는 행사 선택 화면(루트)에서만 본문 아래에 인라인으로 노출된다.
+ */
+export function Sidebar({
+  events,
+  currentSlug,
+  showOnMobile,
+  authEnabled,
+  user,
+}: {
+  events: ApiEvent[];
+  currentSlug: string | null;
+  showOnMobile: boolean;
+  authEnabled: boolean;
+  user: AuthUser | null;
+}) {
+  return (
+    <aside
+      className={
+        (showOnMobile ? "flex flex-1 order-last" : "hidden") +
+        " w-full max-w-[560px] mx-auto flex-col border-x border-line md:order-none md:flex md:max-w-none md:mx-0 md:sticky md:top-0 md:h-screen md:overflow-y-auto md:border-x-0 md:border-r md:bg-card/40"
+      }
+    >
+      <div className="hidden px-5 md:block md:pt-6">
+        <a href="#/" className="text-sm font-extrabold text-accent no-underline">동인행사 체크리스트</a>
+      </div>
+      <nav aria-label="행사" className="flex-1 px-5 pb-6">
+        <EventList events={events} currentSlug={currentSlug} />
+      </nav>
+      {authEnabled ? (
+        <div className="border-t border-line px-5 py-4 text-xs text-faint">
+          {user ? (
+            <div className="flex items-center justify-between gap-2">
+              <span className="truncate">{user.name ?? "로그인됨"} · 동기화 중</span>
+              <button type="button" onClick={logout} className="shrink-0 font-bold text-muted">로그아웃</button>
+            </div>
+          ) : (
+            <button type="button" onClick={login} className="text-left font-semibold text-muted">
+              기기 간 동기화
+            </button>
+          )}
+        </div>
+      ) : null}
+    </aside>
+  );
+}

--- a/src/lib/event.ts
+++ b/src/lib/event.ts
@@ -1,0 +1,8 @@
+import type { ApiEvent } from "../api";
+
+/** 행사 부제: 별칭·장소·기간 중 존재하는 것만 · 로 잇는다. */
+export function eventSubtitle(event: ApiEvent | null): string {
+  if (!event) return "행사 정보를 불러오는 중…";
+  const parts = [event.alias || event.title, event.venue, event.date_label].filter(Boolean);
+  return parts.length ? parts.join(" · ") : event.title;
+}

--- a/test/client/App.test.tsx
+++ b/test/client/App.test.tsx
@@ -74,14 +74,17 @@ describe("<App/> confirmed + unlisted", () => {
     expect(await screen.findByText("부스서클")).toBeTruthy();
   });
 
-  it("sidebar marks the current 행사 and exposes the sync entry only when auth is enabled", async () => {
+  it("marks the current 행사 in the sidebar", async () => {
     window.location.hash = "#/events/ev";
     render(<App />);
     await screen.findByText("부스서클");
     expect(screen.getByRole("link", { name: /코믹월드/ }).getAttribute("aria-current")).toBe("page");
     expect(screen.getByRole("link", { name: /일러스타 페스/ }).getAttribute("aria-current")).toBeNull();
     expect(screen.queryByRole("button", { name: "기기 간 동기화" })).toBeNull();
-    cleanup();
+  });
+
+  it("shows the sync entry only in the sidebar when auth is enabled", async () => {
+    window.location.hash = "#/events/ev";
     mockApi(CIRCLES, true);
     render(<App />);
     expect(await screen.findByRole("button", { name: "기기 간 동기화" })).toBeTruthy();
@@ -93,6 +96,7 @@ describe("<App/> confirmed + unlisted", () => {
     render(<App />);
     fireEvent.click(await screen.findByText("통판서클"));
     expect(screen.getByText("서클 상세")).toBeTruthy();
+    expect(screen.getByText("부스서클")).toBeTruthy(); // 데스크톱 2컬럼: 목록 유지
   });
 
   it("search matches 통판 by name and hides booth circles", async () => {

--- a/test/client/App.test.tsx
+++ b/test/client/App.test.tsx
@@ -19,7 +19,7 @@ const apiCircle = (o: Partial<ApiCircleLike> & { slug: string; name: string; sta
   ...o,
 });
 
-function mockApi(circles: ApiCircleLike[]) {
+function mockApi(circles: ApiCircleLike[], authEnabled = false) {
   const json = (obj: unknown) =>
     new Response(JSON.stringify(obj), { status: 200, headers: { "content-type": "application/json" } });
   vi.stubGlobal(
@@ -33,6 +33,7 @@ function mockApi(circles: ApiCircleLike[]) {
           ],
         });
       if (url.includes("/api/circles")) return json({ circles });
+      if (url.includes("/api/auth/me")) return json({ enabled: authEnabled, user: null });
       throw new Error("unexpected fetch " + url);
     }),
   );
@@ -71,6 +72,20 @@ describe("<App/> confirmed + unlisted", () => {
     fireEvent.click(screen.getByRole("link", { name: /일러스타 페스/ }));
     await waitFor(() => expect(window.location.hash).toBe("#/events/illustar"));
     expect(await screen.findByText("부스서클")).toBeTruthy();
+  });
+
+  it("sidebar marks the current 행사 and exposes the sync entry only when auth is enabled", async () => {
+    window.location.hash = "#/events/ev";
+    render(<App />);
+    await screen.findByText("부스서클");
+    expect(screen.getByRole("link", { name: /코믹월드/ }).getAttribute("aria-current")).toBe("page");
+    expect(screen.getByRole("link", { name: /일러스타 페스/ }).getAttribute("aria-current")).toBeNull();
+    expect(screen.queryByRole("button", { name: "기기 간 동기화" })).toBeNull();
+    cleanup();
+    mockApi(CIRCLES, true);
+    render(<App />);
+    expect(await screen.findByRole("button", { name: "기기 간 동기화" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "로그인" })).toBeNull();
   });
 
   it("opens the 통판 detail from its card", async () => {


### PR DESCRIPTION
## Summary
- `md` 이상: 좌측 사이드바(브랜드 · 행사 목록 진행 중/예정/지난 · 현재 행사 `aria-current` 하이라이트 · 하단 "기기 간 동기화" 로그인 진입점) + 우측 콘텐츠 2컬럼
- 콘텐츠 topbar: 행사 제목/부제 · 검색 · 부스배치도 링크. 본문: 상태 필터 + 장르 칩 + 서클 카드 그리드(md 2열, xl 3열)
- 서클 상세는 데스크톱에서 우측 패널로 표시(목록 유지), 모바일은 기존처럼 전체 화면
- 단일 DOM + 반응형 클래스로만 분기(컴포넌트 공유, #29 모바일 작업과 충돌 없음). 다크모드 토큰 변경 없음
- 헤더의 로그인 버튼 제거 → 사이드바 하단으로 이동(#30 기준). 모바일은 행사 선택 화면에서 접근 가능
- `EventList`/`eventSubtitle`를 `components/Sidebar.tsx`, `lib/event.ts`로 분리

Closes #28

## Test plan
- [x] `npm run typecheck` / `npm test`(63 passed) / `npm run build`
- [x] 신규 테스트: 사이드바 현재 행사 `aria-current="page"`, auth 활성 시에만 "기기 간 동기화" 노출, 헤더 "로그인" 버튼 미노출
- [x] wrangler dev + headless Chromium 스크린샷으로 1440px(목록/상세/루트) · 390px(목록/루트) 확인
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)