### PR TITLE
feat: 모바일 하단 네비게이션 + 검색/필터 시트 (#29)

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     })(window,document,'script','dataLayer','GTM-WGDJT3BD');</script>
     <!-- End Google Tag Manager -->
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#ffffff" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { useAppRoute } from "./hooks/useAppRoute";
 import { Card } from "./components/Card";
 import { Detail } from "./components/Detail";
 import { Sidebar } from "./components/Sidebar";
+import { BottomNav, type Sheet } from "./components/BottomNav";
 import { eventSubtitle } from "./lib/event";
 
 /* ---------- 앱 ---------- */
@@ -22,6 +23,9 @@ export default function App() {
   const [selectedIps, setSelectedIps] = useState<string[]>([]);
   const [query, setQuery] = useState("");
   const [announce, setAnnounce] = useState("");
+  // 모바일 bottom sheet(검색/필터). md 이상에서는 같은 DOM이 topbar에 인라인으로 항상 보인다.
+  const [sheet, setSheet] = useState<Sheet>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
 
   const [circles, setCircles] = useState<Circle[]>([]);
   const [witchformExtra, setWitchformExtra] = useState<Circle[]>([]);
@@ -99,6 +103,23 @@ export default function App() {
     setQuery("");
   }, [requestedEventSlug]);
 
+  // 라우트가 바뀌면(상세 진입/행사 이동) 시트를 닫는다
+  useEffect(() => setSheet(null), [route]);
+
+  const opener = useRef<HTMLElement | null>(null);
+  useEffect(() => {
+    if (!sheet) { opener.current?.focus(); opener.current = null; return; }
+    opener.current = document.activeElement as HTMLElement | null;
+    if (sheet === "search") searchRef.current?.focus();
+    document.body.style.overflow = "hidden";
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setSheet(null); };
+    window.addEventListener("keydown", onKey);
+    return () => {
+      document.body.style.overflow = "";
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [sheet]);
+
   const handleToggle = (id: string) => {
     setAnnounce(checks[id] ? "방문 체크를 해제했어요" : "방문 체크했어요");
     toggle(id);
@@ -125,6 +146,13 @@ export default function App() {
     (active ? "bg-accent/10 text-accent border-accent/30" : "bg-card text-muted border-line");
   // 상세 패널이 열리면 xl에서도 2열 유지(목록 폭이 줄어듦)
   const gridCls = "grid gap-3 md:grid-cols-2 " + (detail ? "" : "xl:grid-cols-3");
+  // 모바일: 시트가 열렸을 때만 하단 패널로 노출(네비 높이만큼 위). md 이상: topbar 인라인.
+  const sheetCls = (s: Exclude<Sheet, null>) =>
+    (sheet === s
+      ? "fixed left-1/2 -translate-x-1/2 w-full max-w-[560px] bottom-0 z-20 rounded-t-[20px] border-t border-line bg-bg px-5 pt-4 pb-[calc(72px+env(safe-area-inset-bottom))] max-h-[75vh] overflow-y-auto "
+      : "hidden ") + "md:static md:block md:translate-x-0 md:max-w-none md:rounded-none md:border-0 md:p-0 md:max-h-none md:overflow-visible";
+  const filterCount = (status === "all" ? 0 : 1) + selectedIps.length;
+  const showNav = route.kind !== "events" && !detailSlug;
 
   return (
     // 쉘: 모바일은 단일 컬럼(560px), md 이상은 사이드바 + 콘텐츠 2컬럼. 컴포넌트는 공유하고 레이아웃만 분기.
@@ -150,21 +178,24 @@ export default function App() {
         ) : (
           <div className="xl:flex xl:items-start">
             {/* 목록 — 상세가 열리면 xl 미만은 숨김(전체 화면 상세), xl 이상은 유지 */}
-            <div className={"min-w-0 flex-1 pb-7 " + (detail ? "hidden xl:block" : "")}>
-              {/* sticky 헤더(모바일) / topbar(데스크톱) */}
-              <div className="sticky top-0 z-10 bg-bg/95 backdrop-blur px-5 pt-[22px] pb-3 border-b border-line md:px-8 md:pt-4">
-                <div className="mb-4 flex items-start justify-between gap-3 md:mb-3 md:items-center md:gap-6">
+            <div className={"min-w-0 flex-1 pb-[calc(80px+env(safe-area-inset-bottom))] md:pb-7 " + (detail ? "hidden xl:block" : "")}>
+              {/* sticky 헤더(모바일: 제목 + 진행률만) / topbar(데스크톱: 검색·필터 인라인) — fixed 시트가 자식이라 backdrop-blur 금지 */}
+              <div className="sticky top-0 z-10 bg-bg px-5 pt-4 pb-3 border-b border-line md:px-8 md:bg-bg/95 md:backdrop-blur">
+                <div className="flex items-center justify-between gap-3 md:mb-3 md:gap-6">
                   <div className="min-w-0">
-                    <div className="text-[22px] font-extrabold -tracking-[0.02em] text-ink leading-none md:text-[19px]">
+                    <div className="text-[19px] font-extrabold -tracking-[0.02em] text-ink leading-none truncate">
                     {event?.title ?? "동인행사 체크리스트"}
                     </div>
                     <div className="text-xs font-semibold text-faint mt-[5px] truncate">
                       {eventSubtitle(event)}
                     </div>
                   </div>
-                  <button type="button" onClick={openEvents} className="shrink-0 rounded-full border border-line bg-card px-3 py-2 text-xs font-bold text-muted md:hidden">행사 목록</button>
+                  <div className="shrink-0 text-[12.5px] font-bold text-accent">방문 {doneCount}/{all.length}</div>
                 </div>
 
+                {sheet ? <button type="button" aria-label="시트 닫기" onClick={() => setSheet(null)} className="fixed inset-0 z-20 bg-black/40 md:hidden" /> : null}
+
+                <div id="sheet-search" role="group" aria-label="검색" className={sheetCls("search")}>
                 <div className="flex items-center gap-2.5 h-12 bg-card border border-line rounded-[14px] px-3.5 md:h-10 md:max-w-[520px]">
                   <svg
                     viewBox="0 0 24 24"
@@ -179,6 +210,7 @@ export default function App() {
                     <path d="M21 21l-4-4" />
                   </svg>
                   <input
+                    ref={searchRef}
                     type="search"
                     value={query}
                     onChange={(e) => setQuery(e.target.value)}
@@ -230,8 +262,10 @@ export default function App() {
                     </a>
                   ) : null}
                 </div>
+                </div>
 
-                <div className="flex gap-2 mt-3.5">
+                <div id="sheet-filter" role="group" aria-label="필터" className={sheetCls("filter")}>
+                <div className="flex gap-2 md:mt-3.5">
                   {STATUS.map((s) => (
                     <button
                       key={s.k}
@@ -243,10 +277,9 @@ export default function App() {
                     </button>
                   ))}
                 </div>
-              </div>
 
-              {/* 장르 칩 (가로 스크롤) */}
-              <div className="flex gap-2 overflow-x-auto no-scrollbar px-5 pt-1 pb-0.5 md:flex-wrap md:px-8 md:pt-4">
+              {/* 장르 칩 — 모바일 시트 안에서는 줄바꿈, 데스크톱은 topbar 아래 */}
+              <div className="flex flex-wrap gap-2 pt-3 md:pt-4 md:max-h-24 md:overflow-y-auto">
                 <button
                   onClick={() => setSelectedIps([])}
                   aria-pressed={selectedIps.length === 0}
@@ -269,17 +302,13 @@ export default function App() {
                   </button>
                 ))}
               </div>
-
-              {/* 진행 표시 */}
-              <div className="flex items-center justify-between px-[22px] pt-3.5 pb-2 md:px-8">
-                <div className="text-[12.5px] font-bold text-faint">참가 서클 {filtered.length}곳</div>
-                <div className="text-[12.5px] font-bold text-accent">
-                  방문 {doneCount}/{all.length}
                 </div>
               </div>
 
+              <div className="px-[22px] pt-3.5 pb-2 text-[12.5px] font-bold text-faint md:px-8">참가 서클 {filtered.length}곳</div>
+
               {/* 카드 목록 — 데스크톱은 2~3열 그리드 */}
-              <div className="px-5 md:px-8">
+              <div className="px-5 md:px-8" {...(sheet ? { inert: "" } : {})}>
                 {loadError && (
                   <div className="text-center py-14" role="alert">
                     <div className="text-[#e0455c] text-sm font-semibold">{loadError}</div>
@@ -360,6 +389,9 @@ export default function App() {
           </div>
         )}
       </main>
+      {showNav && (
+        <BottomNav sheet={sheet} onSheet={setSheet} onEvents={openEvents} searchCount={query ? 1 : 0} filterCount={filterCount} />
+      )}
     </div>
   );
 }

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -1,0 +1,69 @@
+export type Sheet = "search" | "filter" | null;
+
+const ICONS = {
+  list: <><path d="M4 6h16M4 12h16M4 18h16" /></>,
+  search: <><circle cx="11" cy="11" r="7" /><path d="M21 21l-4-4" /></>,
+  filter: <><path d="M4 7h16M7 12h10M10 17h4" /></>,
+  events: <><rect x="3" y="5" width="18" height="16" rx="2" /><path d="M3 10h18M8 3v4M16 3v4" /></>,
+};
+
+function Icon({ name }: { name: keyof typeof ICONS }) {
+  return (
+    <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      {ICONS[name]}
+    </svg>
+  );
+}
+
+function Tab({
+  icon, label, active, badge, onClick, ...aria
+}: {
+  icon: keyof typeof ICONS;
+  label: string;
+  active: boolean;
+  badge?: number;
+  onClick: () => void;
+  "aria-label"?: string;
+  "aria-current"?: "page";
+  "aria-expanded"?: boolean;
+  "aria-controls"?: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={badge ? `${label} ${badge}개 적용` : undefined}
+      {...aria}
+      className={"relative flex flex-1 flex-col items-center justify-center gap-0.5 min-h-[56px] min-w-[44px] text-[11px] font-bold " + (active ? "text-accent" : "text-faint")}
+    >
+      <Icon name={icon} />
+      {label}
+      {badge ? (
+        <span aria-hidden="true" className="absolute top-1.5 right-[calc(50%-20px)] min-w-4 h-4 px-1 rounded-full bg-accent text-bg text-[10px] leading-4 text-center">
+          {badge}
+        </span>
+      ) : null}
+    </button>
+  );
+}
+
+/** 모바일 전용 하단 네비 — md 이상은 사이드바/topbar가 대신한다. */
+export function BottomNav({
+  sheet, onSheet, onEvents, searchCount, filterCount,
+}: {
+  sheet: Sheet;
+  onSheet: (next: Sheet) => void;
+  onEvents: () => void;
+  searchCount: number;
+  filterCount: number;
+}) {
+  const toggle = (s: Exclude<Sheet, null>) => onSheet(sheet === s ? null : s);
+  return (
+    <nav aria-label="하단 메뉴" className="fixed left-1/2 -translate-x-1/2 w-full max-w-[560px] bottom-0 z-30 flex border-t border-line bg-bg pb-[env(safe-area-inset-bottom)] md:hidden">
+      <Tab icon="list" label="목록" active={sheet === null} aria-current={sheet === null ? "page" : undefined} onClick={() => onSheet(null)} />
+      <Tab icon="search" label="검색" active={sheet === "search"} badge={searchCount} aria-expanded={sheet === "search"} aria-controls="sheet-search" onClick={() => toggle("search")} />
+      <Tab icon="filter" label="필터" active={sheet === "filter"} badge={filterCount} aria-expanded={sheet === "filter"} aria-controls="sheet-filter" onClick={() => toggle("filter")} />
+      <Tab icon="events" label="행사" aria-label="행사 목록" active={false} onClick={onEvents} />
+    </nav>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -76,10 +76,3 @@ body {
   font-family: var(--font-sans);
   -webkit-font-smoothing: antialiased;
 }
-
-.no-scrollbar::-webkit-scrollbar {
-  display: none;
-}
-.no-scrollbar {
-  scrollbar-width: none;
-}

--- a/test/client/App.test.tsx
+++ b/test/client/App.test.tsx
@@ -202,3 +202,66 @@ describe("<App/> confirmed + unlisted", () => {
     expect(screen.queryByLabelText("방문 체크")).toBeNull();
   });
 });
+
+describe("<App/> bottom navigation (mobile)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    window.location.hash = "#/events/ev";
+    mockApi(CIRCLES);
+  });
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("renders 4 tabs with 목록 as the current page and 행사 tab navigating to the root", async () => {
+    render(<App />);
+    await screen.findByText("부스서클");
+    const nav = screen.getByRole("navigation", { name: "하단 메뉴" });
+    expect(nav.querySelectorAll("button").length).toBe(4);
+    expect(screen.getByRole("button", { name: "목록" }).getAttribute("aria-current")).toBe("page");
+    fireEvent.click(screen.getByRole("button", { name: "행사 목록" }));
+    await waitFor(() => expect(window.location.hash).toBe("#/"));
+    expect(screen.queryByRole("navigation", { name: "하단 메뉴" })).toBeNull();
+  });
+
+  it("toggles the search/filter sheets and shows the active filter count", async () => {
+    render(<App />);
+    await screen.findByText("부스서클");
+    const search = screen.getByRole("button", { name: "검색" });
+    expect(document.getElementById("sheet-search")!.className).toContain("hidden");
+    search.focus(); // 실제 브라우저에서는 탭 클릭이 포커스를 옮긴다 — 시트 닫힘 후 포커스 복원 검증용
+    fireEvent.click(search);
+    expect(search.getAttribute("aria-expanded")).toBe("true");
+    expect(document.getElementById("sheet-search")!.className).not.toContain("hidden");
+    expect(document.activeElement).toBe(screen.getByRole("searchbox"));
+    fireEvent.change(screen.getByRole("searchbox"), { target: { value: "부스" } });
+    expect(screen.getByRole("button", { name: "검색 1개 적용" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "시트 닫기" }));
+    expect(document.getElementById("sheet-search")!.className).toContain("hidden");
+    expect(document.activeElement).toBe(screen.getByRole("button", { name: "검색 1개 적용" }));
+    fireEvent.change(screen.getByRole("searchbox"), { target: { value: "" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "필터" }));
+    expect(search.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.getByRole("button", { name: "필터" }).getAttribute("aria-expanded")).toBe("true");
+    fireEvent.click(screen.getByRole("button", { name: "체크함" }));
+    fireEvent.click(screen.getByRole("button", { name: "걸즈밴드크라이" }));
+    expect(screen.getByRole("button", { name: "필터 2개 적용" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "목록" }).getAttribute("aria-current")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "목록" }));
+    expect(screen.getByRole("button", { name: "목록" }).getAttribute("aria-current")).toBe("page");
+    fireEvent.click(screen.getByRole("button", { name: "필터 2개 적용" }));
+
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(screen.getByRole("button", { name: "필터 2개 적용" }).getAttribute("aria-expanded")).toBe("false");
+    expect(screen.queryByRole("button", { name: "시트 닫기" })).toBeNull();
+  });
+
+  it("hides the nav while a circle detail is open", async () => {
+    render(<App />);
+    fireEvent.click(await screen.findByText("부스서클"));
+    expect(screen.getByText("서클 상세")).toBeTruthy();
+    expect(screen.queryByRole("navigation", { name: "하단 메뉴" })).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #29

## 변경 요약
- **Bottom Navigation Bar** (`src/components/BottomNav.tsx`, `md:hidden`): 목록 / 검색 / 필터 / 행사 4탭. 56px 터치 타깃, `aria-current`(목록), `aria-expanded`/`aria-controls`(검색·필터), 활성 필터 개수 배지(접근성 이름에도 포함). `env(safe-area-inset-bottom)` + `viewport-fit=cover`.
- **검색·필터 bottom sheet**: 검색바와 상태/장르 칩은 DOM 한 벌만 두고 Tailwind 반응형 클래스로 분기 — 모바일은 시트, `md+`는 기존 topbar 인라인(#31 데스크톱 셸 유지). 스크림·Escape·포커스 복원·body 스크롤 잠금·뒤 목록 `inert`.
- **슬림 헤더**: 제목/부제만 남기고 `행사 목록` 버튼 제거(행사 탭으로 이동). `방문 N/M`은 sticky 헤더 우측에 상시 노출.
- 상세 진입 시 네비 숨김(`detailSlug` 기준, 딥링크 깜빡임 없음). 본문 하단 패딩으로 마지막 카드 가림 방지.
- 네비/시트 폭은 본문 컬럼(560px)에 맞춤. 데스크톱 장르 칩은 `max-h-24` 스크롤로 topbar 높이 상한.

## 검증
- typecheck / vitest 67 / build 통과. 하단 네비 테스트 3건 추가(탭·aria·시트 토글·배지·포커스 복원·상세 시 숨김).
- 실제 Chromium(390/640/1280px)에서 목록·검색 시트·필터 시트·데스크톱 스크린샷 확인. sticky 헤더 안의 `fixed` 시트가 스크롤 후에도 뷰포트 하단에 정확히 붙는 것 확인.

## 비고
- 로그인은 네비에 두지 않음(#30). `filterCircles`/`useChecks` 그대로 재사용.
