### PR TITLE
test: 로그인 UI 최소화 수용 기준 검증 (#30)

### DIFF
--- a/test/client/App.test.tsx
+++ b/test/client/App.test.tsx
@@ -19,7 +19,7 @@ const apiCircle = (o: Partial<ApiCircleLike> & { slug: string; name: string; sta
   ...o,
 });
 
-function mockApi(circles: ApiCircleLike[], authEnabled = false) {
+function mockApi(circles: ApiCircleLike[], authEnabled = false, user: { userId: string; email: null; name: string; avatarUrl: null } | null = null) {
   const json = (obj: unknown) =>
     new Response(JSON.stringify(obj), { status: 200, headers: { "content-type": "application/json" } });
   vi.stubGlobal(
@@ -33,7 +33,7 @@ function mockApi(circles: ApiCircleLike[], authEnabled = false) {
           ],
         });
       if (url.includes("/api/circles")) return json({ circles });
-      if (url.includes("/api/auth/me")) return json({ enabled: authEnabled, user: null });
+      if (url.includes("/api/auth/me")) return json({ enabled: authEnabled, user });
       throw new Error("unexpected fetch " + url);
     }),
   );
@@ -88,6 +88,16 @@ describe("<App/> confirmed + unlisted", () => {
     mockApi(CIRCLES, true);
     render(<App />);
     expect(await screen.findByRole("button", { name: "기기 간 동기화" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "로그인" })).toBeNull();
+  });
+
+  it("keeps name/logout in the sidebar slot only when signed in (#30)", async () => {
+    window.location.hash = "#/events/ev";
+    mockApi(CIRCLES, true, { userId: "u1", email: null, name: "세오코", avatarUrl: null });
+    render(<App />);
+    expect(await screen.findByText("세오코 · 동기화 중")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "로그아웃" }).closest("aside")).not.toBeNull();
+    expect(screen.queryByRole("button", { name: "기기 간 동기화" })).toBeNull();
     expect(screen.queryByRole("button", { name: "로그인" })).toBeNull();
   });
 


### PR DESCRIPTION
## Summary
- #30의 기능 요구(헤더/bottom nav 로그인 버튼 제거, 사이드바 하단 "기기 간 동기화" 단일 진입점, `authEnabled=false` 미렌더)는 #31/#32에서 이미 반영됨
- 남아 있던 검증 공백인 **로그인 상태**(이름 · 동기화 중 + 로그아웃이 사이드바 슬롯에만, 헤더 미노출)를 테스트로 고정
- `useChecks` 동기화 동작 변경 없음

Closes #30

## Test plan
- [x] `test/client/App.test.tsx` 신규 케이스: 로그인 사용자 → 사이드바 `aside` 안에만 이름/로그아웃, "로그인"/"기기 간 동기화" 버튼 없음
- [ ] CI (typecheck · vitest · build) 그린