### PR TITLE
하단 네비게이션 리퀴드 글래스 스타일

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -149,8 +149,8 @@ export default function App() {
   // 모바일: 시트가 열렸을 때만 하단 패널로 노출(네비 높이만큼 위). md 이상: topbar 인라인.
   const sheetCls = (s: Exclude<Sheet, null>) =>
     (sheet === s
-      ? "fixed left-1/2 -translate-x-1/2 w-full max-w-[560px] bottom-0 z-20 rounded-t-[20px] border-t border-line bg-bg px-5 pt-4 pb-[calc(72px+env(safe-area-inset-bottom))] max-h-[75vh] overflow-y-auto "
-      : "hidden ") + "md:static md:block md:translate-x-0 md:max-w-none md:rounded-none md:border-0 md:p-0 md:max-h-none md:overflow-visible";
+      ? "glass fixed left-1/2 -translate-x-1/2 w-full max-w-[560px] bottom-0 z-20 rounded-t-[20px] px-5 pt-4 pb-[calc(80px+env(safe-area-inset-bottom))] max-h-[75vh] overflow-y-auto "
+      : "hidden ") + "md:static md:block md:translate-x-0 md:max-w-none md:rounded-none md:border-0 md:bg-transparent md:backdrop-filter-none md:p-0 md:max-h-none md:overflow-visible";
   const filterCount = (status === "all" ? 0 : 1) + selectedIps.length;
   const showNav = route.kind !== "events" && !detailSlug;
 
@@ -178,7 +178,7 @@ export default function App() {
         ) : (
           <div className="xl:flex xl:items-start">
             {/* 목록 — 상세가 열리면 xl 미만은 숨김(전체 화면 상세), xl 이상은 유지 */}
-            <div className={"min-w-0 flex-1 pb-[calc(80px+env(safe-area-inset-bottom))] md:pb-7 " + (detail ? "hidden xl:block" : "")}>
+            <div className={"min-w-0 flex-1 pb-[calc(80px+env(safe-area-inset-bottom))] md:pb-7 " /* 하단 바 56px + 오프셋 12px + 여백 12px */ + (detail ? "hidden xl:block" : "")}>
               {/* sticky 헤더(모바일: 제목 + 진행률만) / topbar(데스크톱: 검색·필터 인라인) — fixed 시트가 자식이라 backdrop-blur 금지 */}
               <div className="sticky top-0 z-10 bg-bg px-5 pt-4 pb-3 border-b border-line md:px-8 md:bg-bg/95 md:backdrop-blur">
                 <div className="flex items-center justify-between gap-3 md:mb-3 md:gap-6">

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -58,8 +58,15 @@ export function BottomNav({
   filterCount: number;
 }) {
   const toggle = (s: Exclude<Sheet, null>) => onSheet(sheet === s ? null : s);
+  const activeIndex = sheet === "search" ? 1 : sheet === "filter" ? 2 : 0;
   return (
-    <nav aria-label="하단 메뉴" className="fixed left-1/2 -translate-x-1/2 w-full max-w-[560px] bottom-0 z-30 flex border-t border-line bg-bg pb-[env(safe-area-inset-bottom)] md:hidden">
+    <nav aria-label="하단 메뉴" className="glass fixed left-1/2 -translate-x-1/2 w-[calc(100%-24px)] max-w-[536px] bottom-[calc(env(safe-area-inset-bottom)+12px)] z-30 flex rounded-full shadow-[0_8px_30px_rgba(0,0,0,.18)] overflow-hidden md:hidden">
+      {/* 활성 탭 하이라이트 — 탭 사이를 미끄러지듯 이동. 행사 탭은 라우팅이라 인디케이터 없음 */}
+      <span
+        aria-hidden="true"
+        className="absolute inset-y-1.5 left-0 w-1/4 rounded-full bg-accent/12 transition-transform duration-300 ease-out motion-reduce:transition-none"
+        style={{ transform: `translateX(${activeIndex * 100}%)` }}
+      />
       <Tab icon="list" label="목록" active={sheet === null} aria-current={sheet === null ? "page" : undefined} onClick={() => onSheet(null)} />
       <Tab icon="search" label="검색" active={sheet === "search"} badge={searchCount} aria-expanded={sheet === "search"} aria-controls="sheet-search" onClick={() => toggle("search")} />
       <Tab icon="filter" label="필터" active={sheet === "filter"} badge={filterCount} aria-expanded={sheet === "filter"} aria-controls="sheet-filter" onClick={() => toggle("filter")} />

--- a/src/index.css
+++ b/src/index.css
@@ -13,6 +13,8 @@
   --app-fg-3: #6f6f6f;
   --app-accent: #f472b6;
   --app-accent-soft: rgba(244, 114, 182, .14);
+  --glass-bg: rgba(20, 20, 20, .62);
+  --glass-border: rgba(255, 255, 255, .12);
   color-scheme: dark;
 }
 
@@ -28,6 +30,8 @@
   --app-fg-3: #8b8b8b;
   --app-accent: #c8286b;
   --app-accent-soft: rgba(200, 40, 107, .1);
+  --glass-bg: rgba(255, 255, 255, .72);
+  --glass-border: rgba(0, 0, 0, .08);
   color-scheme: light;
 }
 
@@ -44,6 +48,8 @@
     --app-fg-3: #6f6f6f;
     --app-accent: #f472b6;
     --app-accent-soft: rgba(244, 114, 182, .14);
+  --glass-bg: rgba(20, 20, 20, .62);
+  --glass-border: rgba(255, 255, 255, .12);
     color-scheme: dark;
   }
 }
@@ -75,4 +81,21 @@ body {
   color: var(--color-ink);
   font-family: var(--font-sans);
   -webkit-font-smoothing: antialiased;
+}
+
+/* 리퀴드 글래스 재질(#36) — 하단 네비/시트 공용. CSS만, SVG 굴절 필터 없음.
+   @utility로 등록해 md:border-0 같은 반응형 유틸이 덮어쓸 수 있게 한다 */
+@utility glass {
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  -webkit-backdrop-filter: blur(18px) saturate(180%);
+  backdrop-filter: blur(18px) saturate(180%);
+  @supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+    background: var(--app-panel);
+  }
+  @media (prefers-reduced-transparency: reduce) {
+    background: var(--app-panel);
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
+  }
 }


### PR DESCRIPTION
Closes #36
Stacked on #38.

## Summary
- `--glass-bg` / `--glass-border` 토큰(라이트·다크) + `@utility glass`: `backdrop-filter: blur(18px) saturate(180%)`, 1px 하이라이트 보더. `@supports` 미지원 시 불투명 `--app-panel`, `prefers-reduced-transparency`면 blur 제거
- BottomNav: 좌우 12px 여백을 둔 플로팅 pill (`bottom: safe-area + 12px`), 부드러운 그림자, 활성 탭을 따라 `transform`으로 미끄러지는 하이라이트(`motion-reduce`시 즉시)
- 검색/필터 bottom sheet도 같은 `glass` 재질 공유, 하단 패딩을 바 높이에 맞춤
- CSS만. 라이브러리·SVG 필터 없음

## Test plan
- [x] CI typecheck / test / build (기존 하단 메뉴 테스트 4탭·aria-current 계약 유지)
- [ ] iOS Safari에서 유리 재질·safe-area 확인