### PR TITLE
프로필 UI: 아바타 드롭다운 ProfileMenu

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -20,6 +20,8 @@
 - `--color-line: #ecedf0` — 보더
 - `--color-chip: #f1f3f6` — 태그/링크 칩 배경
 - `--color-accent` — 액센트(로즈). 라이트 `#c8286b` / 다크 `#f472b6`, 본문 대비 WCAG AA. 소프트 틴트는 `bg-accent/10`, 보더는 `border-accent/30`.
+- `--color-danger` — 위험/오류 텍스트. 라이트 `#c2283c` / 다크 `#e0455c`.
+- `--glass-bg` / `--glass-border` + `glass` 유틸 — 하단 네비·시트의 리퀴드 글래스 재질(blur+saturate). `backdrop-filter` 미지원·`prefers-reduced-transparency`면 불투명 패널로 폴백.
 
 배지 팔레트(카드 앞 아이콘): `#3e5bff #7c5cff #f43f72 #0ea5a5 #f59e0b #6366f1 #22a559` — 서클 순서대로 배정.
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -172,7 +172,7 @@ export default function App() {
           <div className="px-5 pt-7 pb-2 md:px-8 md:py-10">
             <h1 className="text-[26px] font-extrabold text-ink">행사 선택</h1>
             <p className="mt-2 text-sm text-muted">방문할 행사를 골라 관심 서클을 확인하세요.</p>
-            {loadError ? <div role="alert" className="mt-8 text-sm text-[#e0455c]">{loadError}</div> : null}
+            {loadError ? <div role="alert" className="mt-8 text-sm text-danger">{loadError}</div> : null}
             {!loading && !loadError && events.length === 0 ? <div className="py-14 text-center text-sm text-faint">등록된 행사가 없어요</div> : null}
           </div>
         ) : (
@@ -311,7 +311,7 @@ export default function App() {
               <div className="px-5 md:px-8" {...(sheet ? { inert: "" } : {})}>
                 {loadError && (
                   <div className="text-center py-14" role="alert">
-                    <div className="text-[#e0455c] text-sm font-semibold">{loadError}</div>
+                    <div className="text-danger text-sm font-semibold">{loadError}</div>
                     <button
                       onClick={() => void load()}
                       disabled={loading}

--- a/src/api.ts
+++ b/src/api.ts
@@ -74,14 +74,16 @@ export async function fetchAuth(): Promise<{ enabled: boolean; user: AuthUser | 
   return await res.json();
 }
 
+export const AUTH_ORIGIN = "https://auth.bini59.dev";
+
 export function login(): void {
   const returnTo = `${window.location.origin}${window.location.pathname}${window.location.hash}`;
-  window.location.href = `https://auth.bini59.dev/login?client_id=seoko-maps&return_to=${encodeURIComponent(returnTo)}`;
+  window.location.href = `${AUTH_ORIGIN}/login?client_id=seoko-maps&return_to=${encodeURIComponent(returnTo)}`;
 }
 
 export function logout(): void {
   const returnTo = `${window.location.origin}${window.location.pathname}${window.location.hash}`;
-  window.location.href = `https://auth.bini59.dev/logout?client_id=seoko-maps&return_to=${encodeURIComponent(returnTo)}`;
+  window.location.href = `${AUTH_ORIGIN}/logout?client_id=seoko-maps&return_to=${encodeURIComponent(returnTo)}`;
 }
 
 export async function fetchChecks(eventSlug: string): Promise<ChecksResponse> {

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -61,7 +61,7 @@ export function BottomNav({
   const activeIndex = sheet === "search" ? 1 : sheet === "filter" ? 2 : 0;
   return (
     <nav aria-label="하단 메뉴" className="glass fixed left-1/2 -translate-x-1/2 w-[calc(100%-24px)] max-w-[536px] bottom-[calc(env(safe-area-inset-bottom)+12px)] z-30 flex rounded-full shadow-[0_8px_30px_rgba(0,0,0,.18)] overflow-hidden md:hidden">
-      {/* 활성 탭 하이라이트 — 탭 사이를 미끄러지듯 이동. 행사 탭은 라우팅이라 인디케이터 없음 */}
+      {/* 활성 탭 하이라이트 — 탭 사이를 미끄러지듯 이동. 행사 탭은 라우팅이라 인디케이터 없음. ponytail: 탭 4개 고정(w-1/4) */}
       <span
         aria-hidden="true"
         className="absolute inset-y-1.5 left-0 w-1/4 rounded-full bg-accent/12 transition-transform duration-300 ease-out motion-reduce:transition-none"

--- a/src/components/ProfileMenu.tsx
+++ b/src/components/ProfileMenu.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useId, useRef, useState } from "react";
+import { logout, type AuthUser } from "../api";
+
+const ACCOUNT_CENTER_URL = "https://auth.bini59.dev/client";
+
+/** 320_archive와 동일 — https 아바타만 허용, 파싱 실패는 null */
+function safeAvatarUrl(value: string | null): string | null {
+  if (!value) return null;
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" ? url.toString() : null;
+  } catch {
+    return null;
+  }
+}
+
+function Avatar({ src, fallback, className = "" }: { src: string | null; fallback: string; className?: string }) {
+  return (
+    <span className={"grid h-7 w-7 shrink-0 place-items-center overflow-hidden rounded-full border border-line bg-chip text-[11.5px] font-semibold text-muted " + className}>
+      {src ? <img alt="" src={src} className="h-full w-full object-cover" /> : fallback}
+    </span>
+  );
+}
+
+const ICON = "shrink-0";
+const svgProps = { viewBox: "0 0 24 24", width: 16, height: 16, fill: "none", stroke: "currentColor", strokeWidth: 2, strokeLinecap: "round", strokeLinejoin: "round", "aria-hidden": true } as const;
+
+/**
+ * 아바타 트리거 + 드롭다운(role="menu"). 320_archive `ProfileMenu` 포팅 — 키보드/포커스/aria 동작 동일.
+ * 사이드바 하단에서 위로 열린다(모바일 루트 화면에선 인라인 렌더).
+ */
+export function ProfileMenu({ user }: { user: AuthUser }) {
+  const menuId = useId();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState(false);
+  const wasOpen = useRef(false);
+
+  const displayName = user.name ?? user.email ?? "사용자";
+  const fallback = displayName.slice(0, 1).toUpperCase();
+  const avatarUrl = safeAvatarUrl(user.avatarUrl);
+
+  useEffect(() => {
+    if (!open) {
+      if (wasOpen.current) triggerRef.current?.focus();
+      wasOpen.current = false;
+      return;
+    }
+    wasOpen.current = true;
+    menuRef.current?.querySelector<HTMLElement>('[role="menuitem"]')?.focus();
+
+    const onPointerDown = (event: PointerEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) setOpen(false);
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setOpen(false);
+        return;
+      }
+      if (event.key !== "Tab" && event.key !== "ArrowDown" && event.key !== "ArrowUp") return;
+      const items = Array.from(menuRef.current?.querySelectorAll<HTMLElement>('[role="menuitem"]') ?? []);
+      if (!items.length) return;
+      const current = items.indexOf(document.activeElement as HTMLElement);
+      const forward = event.key === "ArrowDown" || (event.key === "Tab" && !event.shiftKey);
+      event.preventDefault();
+      items[(current + (forward ? 1 : -1) + items.length) % items.length].focus();
+    };
+
+    window.addEventListener("pointerdown", onPointerDown);
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.removeEventListener("pointerdown", onPointerDown);
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open]);
+
+  const itemCls = "flex w-full items-center gap-2.5 rounded-[7px] px-2.5 py-2 text-left text-[13px] no-underline hover:bg-chip ";
+
+  return (
+    <div ref={containerRef} className="relative flex items-center gap-2.5 min-w-0">
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-label="프로필 메뉴"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-controls={open ? menuId : undefined}
+        onClick={() => setOpen((v) => !v)}
+        className="flex min-w-0 items-center gap-2.5 rounded-full text-left"
+      >
+        <Avatar src={avatarUrl} fallback={fallback} className="hover:border-line-strong" />
+        <span className="truncate text-xs font-semibold text-muted">{displayName}</span>
+      </button>
+      {open ? (
+        <div id={menuId} ref={menuRef} role="menu" aria-label="프로필 메뉴" className="absolute bottom-full left-0 z-40 mb-2 w-[232px] overflow-hidden rounded-[10px] border border-line-strong bg-card shadow-lg">
+          <div className="flex items-center gap-2.5 border-b border-line px-3 py-2.5">
+            <Avatar src={avatarUrl} fallback={fallback} />
+            <span className="grid min-w-0">
+              <strong className="truncate text-[12.5px] font-semibold text-ink">{displayName}</strong>
+              {user.email ? <span className="truncate text-[11px] text-faint">{user.email}</span> : null}
+            </span>
+          </div>
+          <div className="grid gap-0.5 p-1.5">
+            <a role="menuitem" href={ACCOUNT_CENTER_URL} target="_blank" rel="noreferrer noopener" onClick={() => setOpen(false)} className={itemCls + "text-muted hover:text-ink"}>
+              <svg {...svgProps} className={ICON}><circle cx="12" cy="8" r="4" /><path d="M4 21a8 8 0 0 1 16 0" /></svg>
+              <span>계정센터</span>
+              <svg {...svgProps} width={13} height={13} className={ICON + " ml-auto text-faint"}><path d="M14 4h6v6M20 4l-9 9M19 14v5a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1h5" /></svg>
+            </a>
+            <button role="menuitem" type="button" onClick={logout} className={itemCls + "text-[#e0455c] hover:bg-[#e0455c]/10"}>
+              <svg {...svgProps} className={ICON}><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4M16 17l5-5-5-5M21 12H9" /></svg>
+              <span>로그아웃</span>
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/ProfileMenu.tsx
+++ b/src/components/ProfileMenu.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useId, useRef, useState } from "react";
-import { logout, type AuthUser } from "../api";
+import { AUTH_ORIGIN, logout, type AuthUser } from "../api";
 
-const ACCOUNT_CENTER_URL = "https://auth.bini59.dev/client";
+const ACCOUNT_CENTER_URL = `${AUTH_ORIGIN}/client`;
 
 /** 320_archive와 동일 — https 아바타만 허용, 파싱 실패는 null */
 function safeAvatarUrl(value: string | null): string | null {
@@ -17,12 +17,11 @@ function safeAvatarUrl(value: string | null): string | null {
 function Avatar({ src, fallback, className = "" }: { src: string | null; fallback: string; className?: string }) {
   return (
     <span className={"grid h-7 w-7 shrink-0 place-items-center overflow-hidden rounded-full border border-line bg-chip text-[11.5px] font-semibold text-muted " + className}>
-      {src ? <img alt="" src={src} className="h-full w-full object-cover" /> : fallback}
+      {src ? <img alt="" src={src} width={28} height={28} referrerPolicy="no-referrer" className="h-full w-full object-cover" /> : fallback}
     </span>
   );
 }
 
-const ICON = "shrink-0";
 const svgProps = { viewBox: "0 0 24 24", width: 16, height: 16, fill: "none", stroke: "currentColor", strokeWidth: 2, strokeLinecap: "round", strokeLinejoin: "round", "aria-hidden": true } as const;
 
 /**
@@ -35,19 +34,18 @@ export function ProfileMenu({ user }: { user: AuthUser }) {
   const triggerRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
   const [open, setOpen] = useState(false);
-  const wasOpen = useRef(false);
+  const restoreFocus = useRef(false); // 키보드로 닫을 때만 트리거로 포커스 복귀 (바깥 클릭은 클릭한 곳 유지)
 
   const displayName = user.name ?? user.email ?? "사용자";
-  const fallback = displayName.slice(0, 1).toUpperCase();
+  const fallback = [...displayName][0]?.toUpperCase() ?? "?";
   const avatarUrl = safeAvatarUrl(user.avatarUrl);
 
   useEffect(() => {
     if (!open) {
-      if (wasOpen.current) triggerRef.current?.focus();
-      wasOpen.current = false;
+      if (restoreFocus.current) triggerRef.current?.focus();
+      restoreFocus.current = false;
       return;
     }
-    wasOpen.current = true;
     menuRef.current?.querySelector<HTMLElement>('[role="menuitem"]')?.focus();
 
     const onPointerDown = (event: PointerEvent) => {
@@ -56,6 +54,7 @@ export function ProfileMenu({ user }: { user: AuthUser }) {
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         event.preventDefault();
+        restoreFocus.current = true;
         setOpen(false);
         return;
       }
@@ -83,7 +82,7 @@ export function ProfileMenu({ user }: { user: AuthUser }) {
       <button
         ref={triggerRef}
         type="button"
-        aria-label="프로필 메뉴"
+        aria-label={`${displayName} 프로필 메뉴`}
         aria-haspopup="menu"
         aria-expanded={open}
         aria-controls={open ? menuId : undefined}
@@ -94,7 +93,7 @@ export function ProfileMenu({ user }: { user: AuthUser }) {
         <span className="truncate text-xs font-semibold text-muted">{displayName}</span>
       </button>
       {open ? (
-        <div id={menuId} ref={menuRef} role="menu" aria-label="프로필 메뉴" className="absolute bottom-full left-0 z-40 mb-2 w-[232px] overflow-hidden rounded-[10px] border border-line-strong bg-card shadow-lg">
+        <div id={menuId} className="absolute bottom-full left-0 z-40 mb-2 w-[232px] overflow-hidden rounded-[10px] border border-line-strong bg-card shadow-lg">
           <div className="flex items-center gap-2.5 border-b border-line px-3 py-2.5">
             <Avatar src={avatarUrl} fallback={fallback} />
             <span className="grid min-w-0">
@@ -102,14 +101,14 @@ export function ProfileMenu({ user }: { user: AuthUser }) {
               {user.email ? <span className="truncate text-[11px] text-faint">{user.email}</span> : null}
             </span>
           </div>
-          <div className="grid gap-0.5 p-1.5">
+          <div ref={menuRef} role="menu" aria-label="프로필 메뉴" className="grid gap-0.5 p-1.5">
             <a role="menuitem" href={ACCOUNT_CENTER_URL} target="_blank" rel="noreferrer noopener" onClick={() => setOpen(false)} className={itemCls + "text-muted hover:text-ink"}>
-              <svg {...svgProps} className={ICON}><circle cx="12" cy="8" r="4" /><path d="M4 21a8 8 0 0 1 16 0" /></svg>
-              <span>계정센터</span>
-              <svg {...svgProps} width={13} height={13} className={ICON + " ml-auto text-faint"}><path d="M14 4h6v6M20 4l-9 9M19 14v5a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1h5" /></svg>
+              <svg {...svgProps} className="shrink-0"><circle cx="12" cy="8" r="4" /><path d="M4 21a8 8 0 0 1 16 0" /></svg>
+              <span>계정센터<span className="sr-only"> (새 창)</span></span>
+              <svg {...svgProps} width={13} height={13} className="ml-auto shrink-0 text-faint"><path d="M14 4h6v6M20 4l-9 9M19 14v5a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1h5" /></svg>
             </a>
-            <button role="menuitem" type="button" onClick={logout} className={itemCls + "text-[#e0455c] hover:bg-[#e0455c]/10"}>
-              <svg {...svgProps} className={ICON}><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4M16 17l5-5-5-5M21 12H9" /></svg>
+            <button role="menuitem" type="button" onClick={logout} className={itemCls + "text-danger hover:bg-danger/10"}>
+              <svg {...svgProps} className="shrink-0"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4M16 17l5-5-5-5M21 12H9" /></svg>
               <span>로그아웃</span>
             </button>
           </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,4 +1,5 @@
-import { login, logout, type ApiEvent, type AuthUser } from "../api";
+import { login, type ApiEvent, type AuthUser } from "../api";
+import { ProfileMenu } from "./ProfileMenu";
 import { eventSubtitle } from "../lib/event";
 
 const EVENT_SECTIONS = [
@@ -76,10 +77,7 @@ export function Sidebar({
       {authEnabled ? (
         <div className="border-t border-line px-5 py-4 text-xs text-faint">
           {user ? (
-            <div className="flex items-center justify-between gap-2">
-              <span className="truncate">{user.name ?? "로그인됨"} · 동기화 중</span>
-              <button type="button" onClick={logout} className="shrink-0 font-bold text-muted">로그아웃</button>
-            </div>
+            <ProfileMenu user={user} />
           ) : (
             <button type="button" onClick={login} className="text-left font-semibold text-muted">
               기기 간 동기화

--- a/src/index.css
+++ b/src/index.css
@@ -12,7 +12,7 @@
   --app-fg-2: #a1a1a1;
   --app-fg-3: #6f6f6f;
   --app-accent: #f472b6;
-  --app-accent-soft: rgba(244, 114, 182, .14);
+  --app-danger: #e0455c;
   --glass-bg: rgba(20, 20, 20, .62);
   --glass-border: rgba(255, 255, 255, .12);
   color-scheme: dark;
@@ -29,7 +29,7 @@
   --app-fg-2: #5f5f5f;
   --app-fg-3: #8b8b8b;
   --app-accent: #c8286b;
-  --app-accent-soft: rgba(200, 40, 107, .1);
+  --app-danger: #c2283c;
   --glass-bg: rgba(255, 255, 255, .72);
   --glass-border: rgba(0, 0, 0, .08);
   color-scheme: light;
@@ -47,9 +47,9 @@
     --app-fg-2: #a1a1a1;
     --app-fg-3: #6f6f6f;
     --app-accent: #f472b6;
-    --app-accent-soft: rgba(244, 114, 182, .14);
-  --glass-bg: rgba(20, 20, 20, .62);
-  --glass-border: rgba(255, 255, 255, .12);
+    --app-danger: #e0455c;
+    --glass-bg: rgba(20, 20, 20, .62);
+    --glass-border: rgba(255, 255, 255, .12);
     color-scheme: dark;
   }
 }
@@ -64,6 +64,7 @@
   --color-line-strong: var(--app-border-strong);
   --color-chip: var(--app-panel-2);
   --color-accent: var(--app-accent);
+  --color-danger: var(--app-danger);
 
   --font-sans: "Pretendard Variable", Pretendard, -apple-system, BlinkMacSystemFont,
     "Apple SD Gothic Neo", sans-serif;

--- a/test/client/App.test.tsx
+++ b/test/client/App.test.tsx
@@ -95,7 +95,7 @@ describe("<App/> confirmed + unlisted", () => {
     window.location.hash = "#/events/ev";
     mockApi(CIRCLES, true, { userId: "u1", email: null, name: "세오코", avatarUrl: null });
     render(<App />);
-    const trigger = await screen.findByRole("button", { name: "프로필 메뉴" });
+    const trigger = await screen.findByRole("button", { name: /프로필 메뉴/ });
     expect(trigger.closest("aside")).not.toBeNull();
     expect(screen.getByText("세오코")).toBeTruthy();
     expect(screen.queryByRole("button", { name: "기기 간 동기화" })).toBeNull();
@@ -231,6 +231,11 @@ describe("<App/> bottom navigation (mobile)", () => {
     const nav = screen.getByRole("navigation", { name: "하단 메뉴" });
     expect(nav.querySelectorAll("button").length).toBe(4);
     expect(screen.getByRole("button", { name: "목록" }).getAttribute("aria-current")).toBe("page");
+    const indicator = nav.querySelector<HTMLElement>('span[aria-hidden="true"]')!;
+    expect(indicator.style.transform).toBe("translateX(0%)");
+    fireEvent.click(screen.getByRole("button", { name: "검색" }));
+    expect(indicator.style.transform).toBe("translateX(100%)");
+    fireEvent.click(screen.getByRole("button", { name: "목록" }));
     fireEvent.click(screen.getByRole("button", { name: "행사 목록" }));
     await waitFor(() => expect(window.location.hash).toBe("#/"));
     expect(screen.queryByRole("navigation", { name: "하단 메뉴" })).toBeNull();

--- a/test/client/App.test.tsx
+++ b/test/client/App.test.tsx
@@ -95,8 +95,9 @@ describe("<App/> confirmed + unlisted", () => {
     window.location.hash = "#/events/ev";
     mockApi(CIRCLES, true, { userId: "u1", email: null, name: "세오코", avatarUrl: null });
     render(<App />);
-    expect(await screen.findByText("세오코 · 동기화 중")).toBeTruthy();
-    expect(screen.getByRole("button", { name: "로그아웃" }).closest("aside")).not.toBeNull();
+    const trigger = await screen.findByRole("button", { name: "프로필 메뉴" });
+    expect(trigger.closest("aside")).not.toBeNull();
+    expect(screen.getByText("세오코")).toBeTruthy();
     expect(screen.queryByRole("button", { name: "기기 간 동기화" })).toBeNull();
     expect(screen.queryByRole("button", { name: "로그인" })).toBeNull();
   });

--- a/test/client/ProfileMenu.test.tsx
+++ b/test/client/ProfileMenu.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, afterEach, vi } from "vitest";
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 import { ProfileMenu } from "../../src/components/ProfileMenu";
 
-vi.mock("../../src/api", () => ({ logout: vi.fn() }));
+vi.mock("../../src/api", () => ({ logout: vi.fn(), AUTH_ORIGIN: "https://auth.bini59.dev" }));
 import { logout } from "../../src/api";
 
 const USER = { userId: "u1", email: "seoko@example.com", name: "세오코", avatarUrl: null };

--- a/test/client/ProfileMenu.test.tsx
+++ b/test/client/ProfileMenu.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { ProfileMenu } from "../../src/components/ProfileMenu";
+
+vi.mock("../../src/api", () => ({ logout: vi.fn() }));
+import { logout } from "../../src/api";
+
+const USER = { userId: "u1", email: "seoko@example.com", name: "세오코", avatarUrl: null };
+
+describe("<ProfileMenu/>", () => {
+  afterEach(cleanup);
+
+  it("toggles the menu from the avatar trigger and shows account center + logout", () => {
+    render(<ProfileMenu user={USER} />);
+    const trigger = screen.getByRole("button", { name: "프로필 메뉴" });
+    expect(screen.queryByRole("menu")).toBeNull();
+    fireEvent.click(trigger);
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+    const link = screen.getByRole("menuitem", { name: "계정센터" });
+    expect(link.getAttribute("href")).toBe("https://auth.bini59.dev/client");
+    expect(link.getAttribute("target")).toBe("_blank");
+    expect(screen.getByText("seoko@example.com")).toBeTruthy();
+    expect(document.activeElement).toBe(link); // 열리면 첫 항목 포커스
+    fireEvent.click(trigger);
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("closes on Escape and returns focus to the trigger", () => {
+    render(<ProfileMenu user={USER} />);
+    const trigger = screen.getByRole("button", { name: "프로필 메뉴" });
+    fireEvent.click(trigger);
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(screen.queryByRole("menu")).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("closes on outside pointerdown but not inside", () => {
+    render(<div><ProfileMenu user={USER} /><p>바깥</p></div>);
+    fireEvent.click(screen.getByRole("button", { name: "프로필 메뉴" }));
+    fireEvent.pointerDown(screen.getByRole("menu"));
+    expect(screen.getByRole("menu")).toBeTruthy();
+    fireEvent.pointerDown(screen.getByText("바깥"));
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("cycles focus with ArrowDown/ArrowUp and calls logout", () => {
+    render(<ProfileMenu user={USER} />);
+    fireEvent.click(screen.getByRole("button", { name: "프로필 메뉴" }));
+    const out = screen.getByRole("menuitem", { name: "로그아웃" });
+    fireEvent.keyDown(window, { key: "ArrowDown" });
+    expect(document.activeElement).toBe(out);
+    fireEvent.keyDown(window, { key: "ArrowDown" }); // 순환
+    expect(document.activeElement).toBe(screen.getByRole("menuitem", { name: "계정센터" }));
+    fireEvent.click(out);
+    expect(logout).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders only https avatars, falls back to the initial otherwise", () => {
+    const { unmount } = render(<ProfileMenu user={{ ...USER, avatarUrl: "http://x/a.png" }} />);
+    expect(document.querySelector("img")).toBeNull();
+    expect(screen.getByRole("button", { name: "프로필 메뉴" }).textContent).toContain("세");
+    unmount();
+    render(<ProfileMenu user={{ ...USER, avatarUrl: "https://x/a.png" }} />);
+    expect(document.querySelector("img")?.getAttribute("src")).toBe("https://x/a.png");
+  });
+});

--- a/test/client/ProfileMenu.test.tsx
+++ b/test/client/ProfileMenu.test.tsx
@@ -13,11 +13,11 @@ describe("<ProfileMenu/>", () => {
 
   it("toggles the menu from the avatar trigger and shows account center + logout", () => {
     render(<ProfileMenu user={USER} />);
-    const trigger = screen.getByRole("button", { name: "프로필 메뉴" });
+    const trigger = screen.getByRole("button", { name: /프로필 메뉴/ });
     expect(screen.queryByRole("menu")).toBeNull();
     fireEvent.click(trigger);
     expect(trigger.getAttribute("aria-expanded")).toBe("true");
-    const link = screen.getByRole("menuitem", { name: "계정센터" });
+    const link = screen.getByRole("menuitem", { name: /계정센터/ });
     expect(link.getAttribute("href")).toBe("https://auth.bini59.dev/client");
     expect(link.getAttribute("target")).toBe("_blank");
     expect(screen.getByText("seoko@example.com")).toBeTruthy();
@@ -28,7 +28,7 @@ describe("<ProfileMenu/>", () => {
 
   it("closes on Escape and returns focus to the trigger", () => {
     render(<ProfileMenu user={USER} />);
-    const trigger = screen.getByRole("button", { name: "프로필 메뉴" });
+    const trigger = screen.getByRole("button", { name: /프로필 메뉴/ });
     fireEvent.click(trigger);
     fireEvent.keyDown(window, { key: "Escape" });
     expect(screen.queryByRole("menu")).toBeNull();
@@ -37,7 +37,7 @@ describe("<ProfileMenu/>", () => {
 
   it("closes on outside pointerdown but not inside", () => {
     render(<div><ProfileMenu user={USER} /><p>바깥</p></div>);
-    fireEvent.click(screen.getByRole("button", { name: "프로필 메뉴" }));
+    fireEvent.click(screen.getByRole("button", { name: /프로필 메뉴/ }));
     fireEvent.pointerDown(screen.getByRole("menu"));
     expect(screen.getByRole("menu")).toBeTruthy();
     fireEvent.pointerDown(screen.getByText("바깥"));
@@ -46,20 +46,36 @@ describe("<ProfileMenu/>", () => {
 
   it("cycles focus with ArrowDown/ArrowUp and calls logout", () => {
     render(<ProfileMenu user={USER} />);
-    fireEvent.click(screen.getByRole("button", { name: "프로필 메뉴" }));
+    fireEvent.click(screen.getByRole("button", { name: /프로필 메뉴/ }));
     const out = screen.getByRole("menuitem", { name: "로그아웃" });
     fireEvent.keyDown(window, { key: "ArrowDown" });
     expect(document.activeElement).toBe(out);
     fireEvent.keyDown(window, { key: "ArrowDown" }); // 순환
-    expect(document.activeElement).toBe(screen.getByRole("menuitem", { name: "계정센터" }));
+    expect(document.activeElement).toBe(screen.getByRole("menuitem", { name: /계정센터/ }));
+    fireEvent.keyDown(window, { key: "Tab", shiftKey: true });
+    expect(document.activeElement).toBe(out);
     fireEvent.click(out);
     expect(logout).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes when the account center link is clicked and keeps focus where an outside click landed", () => {
+    render(<div><ProfileMenu user={USER} /><button>바깥</button></div>);
+    const trigger = screen.getByRole("button", { name: /프로필 메뉴/ });
+    fireEvent.click(trigger);
+    fireEvent.click(screen.getByRole("menuitem", { name: /계정센터/ }));
+    expect(screen.queryByRole("menu")).toBeNull();
+    fireEvent.click(trigger);
+    const outside = screen.getByRole("button", { name: "바깥" });
+    outside.focus();
+    fireEvent.pointerDown(outside);
+    expect(screen.queryByRole("menu")).toBeNull();
+    expect(document.activeElement).toBe(outside);
   });
 
   it("renders only https avatars, falls back to the initial otherwise", () => {
     const { unmount } = render(<ProfileMenu user={{ ...USER, avatarUrl: "http://x/a.png" }} />);
     expect(document.querySelector("img")).toBeNull();
-    expect(screen.getByRole("button", { name: "프로필 메뉴" }).textContent).toContain("세");
+    expect(screen.getByRole("button", { name: /프로필 메뉴/ }).textContent).toContain("세");
     unmount();
     render(<ProfileMenu user={{ ...USER, avatarUrl: "https://x/a.png" }} />);
     expect(document.querySelector("img")?.getAttribute("src")).toBe("https://x/a.png");


### PR DESCRIPTION
Closes #37
Stacked on #39.

## Summary
- `src/components/ProfileMenu.tsx` 신규 — 320_archive `ProfileMenu`를 Tailwind로 이식. 아바타 트리거(https만 허용, 없으면 이니셜) + `role="menu"` 드롭다운: 헤더(아바타·이름·이메일) → 계정센터(`auth.bini59.dev/client`, 새 창) → 로그아웃(danger). 환경설정은 화면이 없어 제외
- 키보드/포커스/aria는 원본 그대로: Escape·바깥 클릭 닫힘, ArrowUp/Down·Tab 순환, 닫힐 때 트리거로 포커스 복귀
- 배치: 사이드바 하단 슬롯(데스크톱 상시, 모바일은 루트 행사 화면에서 인라인). 헤더 미노출(#30). 비로그인은 `기기 간 동기화` 버튼 유지

## Test plan
- [x] `test/client/ProfileMenu.test.tsx`: 열기/닫기, Escape+포커스 복원, 바깥 pointerdown, 화살표 순환, logout 호출, http 아바타 차단
- [x] App 테스트: 로그인 상태에서 트리거가 사이드바 안에만 존재