### PR TITLE
fix: logout via server-side POST to 321_auth (#34)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Circle } from "./types";
-import { fetchAuth, fetchCircles, fetchEvents, pickActiveEvent, type ApiEvent, type AuthUser } from "./api";
+import { fetchAuth, fetchCircles, fetchEvents, logout, pickActiveEvent, type ApiEvent, type AuthUser } from "./api";
 import { badgeColor, filterCircles, STATUS, type Status } from "./lib/circle";
 import { useChecks } from "./hooks/useChecks";
 import { useAppRoute } from "./hooks/useAppRoute";
@@ -44,6 +44,11 @@ export default function App() {
       setAuthEnabled(false);
       setUser(null);
     }).finally(() => setAuthLoading(false));
+  }, []);
+
+  // 워커가 쿠키를 지우므로 revoke 결과와 무관하게 클라이언트는 로그아웃 상태로 전환한다.
+  const handleLogout = useCallback(() => {
+    void logout().catch(() => {}).finally(() => setUser(null));
   }, []);
 
   // 행사장 서클 + 통판(unlisted)을 한 데이터셋으로 다뤄 검색·필터·체크를 일관 적용
@@ -166,6 +171,7 @@ export default function App() {
         showOnMobile={route.kind === "events"}
         authEnabled={authEnabled}
         user={user}
+        onLogout={handleLogout}
       />
       <main className={"w-full max-w-[560px] mx-auto border-x border-line md:max-w-none md:mx-0 md:border-x-0 md:min-h-screen " + (route.kind === "events" ? "" : "flex-1")}>
         {route.kind === "events" ? (

--- a/src/api.ts
+++ b/src/api.ts
@@ -79,9 +79,8 @@ export function login(): void {
   window.location.href = `https://auth.bini59.dev/login?client_id=seoko-maps&return_to=${encodeURIComponent(returnTo)}`;
 }
 
-export function logout(): void {
-  const returnTo = `${window.location.origin}${window.location.pathname}${window.location.hash}`;
-  window.location.href = `https://auth.bini59.dev/logout?client_id=seoko-maps&return_to=${encodeURIComponent(returnTo)}`;
+export async function logout(): Promise<void> {
+  await fetch("/api/auth/logout", { method: "POST", credentials: "include" });
 }
 
 export async function fetchChecks(eventSlug: string): Promise<ChecksResponse> {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { login, logout, type ApiEvent, type AuthUser } from "../api";
+import { login, type ApiEvent, type AuthUser } from "../api";
 import { eventSubtitle } from "../lib/event";
 
 const EVENT_SECTIONS = [
@@ -53,12 +53,14 @@ export function Sidebar({
   showOnMobile,
   authEnabled,
   user,
+  onLogout,
 }: {
   events: ApiEvent[];
   currentSlug: string | null;
   showOnMobile: boolean;
   authEnabled: boolean;
   user: AuthUser | null;
+  onLogout: () => void;
 }) {
   return (
     <aside
@@ -78,7 +80,7 @@ export function Sidebar({
           {user ? (
             <div className="flex items-center justify-between gap-2">
               <span className="truncate">{user.name ?? "로그인됨"} · 동기화 중</span>
-              <button type="button" onClick={logout} className="shrink-0 font-bold text-muted">로그아웃</button>
+              <button type="button" onClick={onLogout} className="shrink-0 font-bold text-muted">로그아웃</button>
             </div>
           ) : (
             <button type="button" onClick={login} className="text-left font-semibold text-muted">

--- a/test/client/App.test.tsx
+++ b/test/client/App.test.tsx
@@ -33,6 +33,7 @@ function mockApi(circles: ApiCircleLike[], authEnabled = false, user: { userId: 
           ],
         });
       if (url.includes("/api/circles")) return json({ circles });
+      if (url.includes("/api/auth/logout")) return json({ ok: true });
       if (url.includes("/api/auth/me")) return json({ enabled: authEnabled, user });
       throw new Error("unexpected fetch " + url);
     }),
@@ -99,6 +100,29 @@ describe("<App/> confirmed + unlisted", () => {
     expect(screen.getByRole("button", { name: "로그아웃" }).closest("aside")).not.toBeNull();
     expect(screen.queryByRole("button", { name: "기기 간 동기화" })).toBeNull();
     expect(screen.queryByRole("button", { name: "로그인" })).toBeNull();
+  });
+
+  it("logs out with a POST to the worker and falls back to the sync entry (#34)", async () => {
+    window.location.hash = "#/events/ev";
+    mockApi(CIRCLES, true, { userId: "u1", email: null, name: "세오코", avatarUrl: null });
+    render(<App />);
+    fireEvent.click(await screen.findByRole("button", { name: "로그아웃" }));
+    expect(await screen.findByRole("button", { name: "기기 간 동기화" })).toBeTruthy();
+    expect(vi.mocked(fetch)).toHaveBeenCalledWith("/api/auth/logout", { method: "POST", credentials: "include" });
+    expect(screen.queryByText("세오코 · 동기화 중")).toBeNull();
+  });
+
+  it("still signs out locally when the logout request fails (#34)", async () => {
+    window.location.hash = "#/events/ev";
+    mockApi(CIRCLES, true, { userId: "u1", email: null, name: "세오코", avatarUrl: null });
+    const base = vi.mocked(fetch).getMockImplementation()!;
+    vi.mocked(fetch).mockImplementation(async (url, init) => {
+      if (String(url).includes("/api/auth/logout")) throw new Error("offline");
+      return base(url, init);
+    });
+    render(<App />);
+    fireEvent.click(await screen.findByRole("button", { name: "로그아웃" }));
+    expect(await screen.findByRole("button", { name: "기기 간 동기화" })).toBeTruthy();
   });
 
   it("opens the 통판 detail from its card", async () => {

--- a/test/worker/api.test.ts
+++ b/test/worker/api.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { app, determineEventStatus } from "../../worker/app";
 import { makeTestDB } from "../helpers/d1";
 
@@ -30,6 +30,7 @@ describe("worker API", () => {
   beforeEach(() => {
     env = makeEnv();
   });
+  afterEach(() => vi.restoreAllMocks());
 
   it("rejects mutations without a valid bearer token", async () => {
     const r = await call(env, "POST", "/api/events", { slug: "e", title: "t" }, false);
@@ -71,6 +72,76 @@ describe("worker API", () => {
       {} as ExecutionContext,
     );
     expect(await loaded.json()).toEqual({ checks: { booth: true } });
+  });
+
+  it("logs out via server-side POST to 321_auth and clears the sid cookie (#34)", async () => {
+    const authFetch = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 302 }));
+    const authEnv = { ...env, AUTH_ORIGIN: "https://auth.bini59.dev", AUTH_CLIENT_ID: "seoko-maps", AUTH_CLIENT_SECRET: "secret" };
+    const r = await app.fetch(
+      new Request("http://x/api/auth/logout", { method: "POST", headers: { cookie: "sid=session; other=1" } }),
+      authEnv,
+      {} as ExecutionContext,
+    );
+    expect(r.status).toBe(200);
+    const [url, init] = authFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://auth.bini59.dev/logout?client_id=seoko-maps");
+    expect(init.method).toBe("POST");
+    const headers = init.headers as Record<string, string>;
+    expect(headers.cookie).toBe(`sid=session; csrf=${headers["x-csrf-token"]}`);
+    expect(headers["x-csrf-token"]).toBeTruthy();
+    const cookies = r.headers.getSetCookie();
+    expect(cookies.some((c) => c.startsWith("sid=;") && c.includes("Max-Age=0") && !c.includes("Domain="))).toBe(true);
+    expect(cookies.some((c) => c.startsWith("sid=;") && c.includes("Domain=bini59.dev"))).toBe(true);
+    expect(await r.json()).toEqual({ ok: true, revoked: true });
+  });
+
+  it("still clears the local sid cookie when 321_auth revoke fails (#34)", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("down"));
+    const authEnv = { ...env, AUTH_ORIGIN: "https://auth.bini59.dev", AUTH_CLIENT_ID: "seoko-maps", AUTH_CLIENT_SECRET: "secret" };
+    const r = await app.fetch(
+      new Request("http://x/api/auth/logout", { method: "POST", headers: { cookie: "sid=session" } }),
+      authEnv,
+      {} as ExecutionContext,
+    );
+    expect(r.status).toBe(200);
+    expect(r.headers.getSetCookie().some((c) => c.startsWith("sid=;") && c.includes("Max-Age=0"))).toBe(true);
+  });
+
+  it("reports revoked=false when 321_auth rejects the logout (#34)", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 403 }));
+    const authEnv = { ...env, AUTH_ORIGIN: "https://auth.bini59.dev", AUTH_CLIENT_ID: "seoko-maps", AUTH_CLIENT_SECRET: "secret" };
+    const r = await app.fetch(
+      new Request("http://x/api/auth/logout", { method: "POST", headers: { cookie: "sid=session" } }),
+      authEnv,
+      {} as ExecutionContext,
+    );
+    expect(await r.json()).toEqual({ ok: true, revoked: false });
+  });
+
+  it("skips the upstream call without a sid cookie but still clears it (#34)", async () => {
+    const authFetch = vi.spyOn(globalThis, "fetch");
+    const authEnv = { ...env, AUTH_ORIGIN: "https://auth.bini59.dev", AUTH_CLIENT_ID: "seoko-maps", AUTH_CLIENT_SECRET: "secret" };
+    const r = await app.fetch(new Request("http://x/api/auth/logout", { method: "POST" }), authEnv, {} as ExecutionContext);
+    expect(r.status).toBe(200);
+    expect(authFetch).not.toHaveBeenCalled();
+    expect(r.headers.getSetCookie().some((c) => c.startsWith("sid=;"))).toBe(true);
+  });
+
+  it("rejects cross-site logout requests (#34)", async () => {
+    const authFetch = vi.spyOn(globalThis, "fetch");
+    for (const headers of [{ "sec-fetch-site": "cross-site", cookie: "sid=s" }, { origin: "https://evil.example", cookie: "sid=s" }]) {
+      const r = await app.fetch(new Request("http://x/api/auth/logout", { method: "POST", headers }), env, {} as ExecutionContext);
+      expect(r.status).toBe(403);
+    }
+    expect(authFetch).not.toHaveBeenCalled();
+    const ok = await app.fetch(
+      new Request("http://x/api/auth/logout", { method: "POST", headers: { "sec-fetch-site": "same-origin", origin: "http://x" } }),
+      env,
+      {} as ExecutionContext,
+    );
+    expect(ok.status).toBe(200);
   });
 
   it("creates an event and lists it", async () => {

--- a/worker/app.ts
+++ b/worker/app.ts
@@ -181,9 +181,10 @@ app.use("*", cors({
   },
 }));
 
-// require bearer token for mutating routes only
+// require bearer token for mutating routes only (session-cookie routes are exempt)
+const SESSION_ROUTES = ["/api/checks", "/api/auth/logout"];
 app.use("*", async (c, next) => {
-  if (["POST", "PATCH", "PUT", "DELETE"].includes(c.req.method) && c.req.path !== "/api/checks") {
+  if (["POST", "PATCH", "PUT", "DELETE"].includes(c.req.method) && !SESSION_ROUTES.includes(c.req.path)) {
     const auth = c.req.header("authorization") || "";
     const token = auth.startsWith("Bearer ") ? auth.slice(7) : "";
     if (!c.env.ADMIN_TOKEN || token !== c.env.ADMIN_TOKEN) {
@@ -197,6 +198,43 @@ app.use("*", async (c, next) => {
 app.get("/auth/me", async (c) => {
   const user = await verifyAuth(c);
   return c.json({ enabled: authConfigured(c.env), user });
+});
+
+// 321_auth `/logout`은 POST + CSRF double-submit 전용이라 브라우저가 직접 못 부른다.
+// 워커가 sid를 대신 넘겨 서버 간 POST로 세션을 revoke하고, 로컬 sid 쿠키를 지운다.
+app.post("/auth/logout", async (c) => {
+  // 우리 라우트가 321_auth의 CSRF 가드를 대신 만족시키므로, 타 출처 폼 POST로 강제 로그아웃되지 않게 출처를 확인한다.
+  const site = c.req.header("sec-fetch-site");
+  const origin = c.req.header("origin");
+  const crossSite = (site && site !== "same-origin") || (origin && new URL(origin).host !== new URL(c.req.url).host);
+  if (crossSite) return c.json({ error: "forbidden", code: "forbidden" }, 403);
+
+  const sid = /(?:^|;\s*)sid=([A-Za-z0-9._~+/=-]+)/.exec(c.req.header("cookie") ?? "")?.[1];
+  let revoked = false;
+  if (sid && authConfigured(c.env)) {
+    const csrf = crypto.randomUUID();
+    const url = new URL("/logout", c.env.AUTH_ORIGIN);
+    url.searchParams.set("client_id", c.env.AUTH_CLIENT_ID!);
+    try {
+      const res = await fetch(url.toString(), {
+        method: "POST",
+        headers: { cookie: `sid=${sid}; csrf=${csrf}`, "x-csrf-token": csrf },
+        redirect: "manual",
+        signal: AbortSignal.timeout(3000),
+      });
+      revoked = res.ok || res.status === 302;
+      if (!revoked) console.error("321_auth logout revoke failed", res.status);
+    } catch (error) {
+      // revoke가 실패해도 로컬 쿠키는 지워 반쯤 로그아웃된 상태를 피한다.
+      console.error("321_auth logout revoke error", error);
+    }
+  }
+  // sid는 321_auth가 상위 도메인(.bini59.dev)으로 심으므로 host-only와 상위 도메인 둘 다 지운다.
+  const expired = "sid=; Max-Age=0; Path=/; HttpOnly; Secure; SameSite=Lax";
+  c.header("set-cookie", expired, { append: true });
+  const parent = c.env.AUTH_ORIGIN ? new URL(c.env.AUTH_ORIGIN).hostname.split(".").slice(1).join(".") : "";
+  if (parent.includes(".")) c.header("set-cookie", `${expired}; Domain=${parent}`, { append: true });
+  return c.json({ ok: true, revoked });
 });
 
 app.get("/checks", async (c) => {


### PR DESCRIPTION
## Summary
- \`worker/app.ts\`: new \`POST /api/auth/logout\`. Reads the \`sid\` cookie, POSTs server-to-server to \`{AUTH_ORIGIN}/logout?client_id=…\` with \`cookie: sid=…; csrf=<rand>\` + \`x-csrf-token\` (satisfies 321_auth's CsrfGuard), 3s timeout, logs a non-302/2xx result and returns \`revoked: false\`. Always clears the local \`sid\` cookie (host-only and \`Domain=bini59.dev\` derived from AUTH_ORIGIN). Rejects cross-site requests (Sec-Fetch-Site / Origin) so the proxy doesn't re-open the CSRF hole upstream guards against. Exempt from the admin bearer check like \`/api/checks\`.
- \`src/api.ts\`: \`logout()\` → \`fetch POST /api/auth/logout\`; no more GET redirect to the POST-only endpoint.
- \`src/App.tsx\` / \`Sidebar.tsx\`: logout handler passed as a prop, sets user to null even if the request fails. \`useChecks\` flips back to localStorage automatically.

## Test plan
- [x] worker: outbound POST shape (URL, csrf cookie == header), Set-Cookie clears (host-only + Domain), upstream 403 → \`revoked:false\`, upstream throw still clears, no sid → no upstream call, cross-site → 403
- [x] client: click 로그아웃 → POST sent, sync entry reappears; logout request failing still signs out locally
- [x] typecheck / vitest (75) / build green
- [ ] prod: sign in, click 로그아웃, reload → still signed out; check other bini59.dev apps also signed out

Closes #34