### PR TITLE
feat: 모바일 행사 전환을 bottom sheet로 — 네비게이션 바 유지 (#42)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,13 +6,13 @@ import { useChecks } from "./hooks/useChecks";
 import { useAppRoute } from "./hooks/useAppRoute";
 import { Card } from "./components/Card";
 import { Detail } from "./components/Detail";
-import { Sidebar } from "./components/Sidebar";
+import { EventList, Sidebar } from "./components/Sidebar";
 import { BottomNav, type Sheet } from "./components/BottomNav";
 import { eventSubtitle } from "./lib/event";
 
 /* ---------- 앱 ---------- */
 export default function App() {
-  const { route, openCircle, openEvents, backToEvent } = useAppRoute();
+  const { route, openCircle, backToEvent } = useAppRoute();
   const [events, setEvents] = useState<ApiEvent[]>([]);
   const [event, setEvent] = useState<ApiEvent | null>(null);
   const [authEnabled, setAuthEnabled] = useState(false);
@@ -23,7 +23,7 @@ export default function App() {
   const [selectedIps, setSelectedIps] = useState<string[]>([]);
   const [query, setQuery] = useState("");
   const [announce, setAnnounce] = useState("");
-  // 모바일 bottom sheet(검색/필터). md 이상에서는 같은 DOM이 topbar에 인라인으로 항상 보인다.
+  // 모바일 bottom sheet(검색/필터/행사). 검색·필터는 md 이상에서 topbar에 인라인, 행사는 사이드바가 대신한다.
   const [sheet, setSheet] = useState<Sheet>(null);
   const searchRef = useRef<HTMLInputElement>(null);
 
@@ -116,6 +116,8 @@ export default function App() {
     if (!sheet) { opener.current?.focus(); opener.current = null; return; }
     opener.current = document.activeElement as HTMLElement | null;
     if (sheet === "search") searchRef.current?.focus();
+    // 시트가 네비보다 DOM 앞에 있어 Tab으로 못 들어간다 — 첫 항목으로 포커스 이동
+    if (sheet === "events") document.querySelector<HTMLAnchorElement>("#sheet-events a")?.focus();
     document.body.style.overflow = "hidden";
     const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setSheet(null); };
     window.addEventListener("keydown", onKey);
@@ -152,11 +154,14 @@ export default function App() {
   // 상세 패널이 열리면 xl에서도 2열 유지(목록 폭이 줄어듦)
   const gridCls = "grid gap-3 md:grid-cols-2 " + (detail ? "" : "xl:grid-cols-3");
   // 모바일: 시트가 열렸을 때만 하단 패널로 노출(네비 높이만큼 위). md 이상: topbar 인라인.
-  const sheetCls = (s: Exclude<Sheet, null>) =>
-    (sheet === s
+  const sheetPanel = (s: Exclude<Sheet, null>) =>
+    sheet === s
       ? "glass fixed left-1/2 -translate-x-1/2 w-full max-w-[560px] bottom-0 z-20 rounded-t-[20px] px-5 pt-4 pb-[calc(80px+env(safe-area-inset-bottom))] max-h-[75vh] overflow-y-auto "
-      : "hidden ") + "md:static md:block md:translate-x-0 md:max-w-none md:rounded-none md:border-0 md:bg-transparent md:backdrop-filter-none md:p-0 md:max-h-none md:overflow-visible";
+      : "hidden ";
+  const sheetCls = (s: Exclude<Sheet, null>) =>
+    sheetPanel(s) + "md:static md:block md:translate-x-0 md:max-w-none md:rounded-none md:border-0 md:bg-transparent md:backdrop-filter-none md:p-0 md:max-h-none md:overflow-visible";
   const filterCount = (status === "all" ? 0 : 1) + selectedIps.length;
+  // 행사 랜딩(#/events)은 네비 없이 목록만, 서클 상세는 뒤로가기가 명확한 서브 화면
   const showNav = route.kind !== "events" && !detailSlug;
 
   return (
@@ -309,6 +314,17 @@ export default function App() {
                 ))}
               </div>
                 </div>
+
+                {/* 행사 전환 시트 — 항목 탭 시 닫힘(현재 행사를 다시 눌러도 hashchange가 없어 명시적으로 닫는다). md 이상은 사이드바가 담당 */}
+                <div id="sheet-events" role="group" aria-label="행사 전환" onClick={() => setSheet(null)} className={sheetPanel("events") + "md:hidden"}>
+                  {sheet === "events" ? (
+                    <>
+                      <div className="text-xs font-extrabold tracking-[0.04em] text-faint">현재 행사</div>
+                      <div className="mt-1 text-[17px] font-extrabold text-ink truncate">{event?.title}</div>
+                      <EventList events={events} currentSlug={event?.slug ?? null} />
+                    </>
+                  ) : null}
+                </div>
               </div>
 
               <div className="px-[22px] pt-3.5 pb-2 text-[12.5px] font-bold text-faint md:px-8">참가 서클 {filtered.length}곳</div>
@@ -396,7 +412,7 @@ export default function App() {
         )}
       </main>
       {showNav && (
-        <BottomNav sheet={sheet} onSheet={setSheet} onEvents={openEvents} searchCount={query ? 1 : 0} filterCount={filterCount} />
+        <BottomNav sheet={sheet} onSheet={setSheet} searchCount={query ? 1 : 0} filterCount={filterCount} />
       )}
     </div>
   );

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -1,4 +1,4 @@
-export type Sheet = "search" | "filter" | null;
+export type Sheet = "search" | "filter" | "events" | null;
 
 const ICONS = {
   list: <><path d="M4 6h16M4 12h16M4 18h16" /></>,
@@ -49,19 +49,18 @@ function Tab({
 
 /** 모바일 전용 하단 네비 — md 이상은 사이드바/topbar가 대신한다. */
 export function BottomNav({
-  sheet, onSheet, onEvents, searchCount, filterCount,
+  sheet, onSheet, searchCount, filterCount,
 }: {
   sheet: Sheet;
   onSheet: (next: Sheet) => void;
-  onEvents: () => void;
   searchCount: number;
   filterCount: number;
 }) {
   const toggle = (s: Exclude<Sheet, null>) => onSheet(sheet === s ? null : s);
-  const activeIndex = sheet === "search" ? 1 : sheet === "filter" ? 2 : 0;
+  const activeIndex = sheet === "search" ? 1 : sheet === "filter" ? 2 : sheet === "events" ? 3 : 0;
   return (
     <nav aria-label="하단 메뉴" className="glass fixed left-1/2 -translate-x-1/2 w-[calc(100%-24px)] max-w-[536px] bottom-[calc(env(safe-area-inset-bottom)+12px)] z-30 flex rounded-full shadow-[0_8px_30px_rgba(0,0,0,.18)] overflow-hidden md:hidden">
-      {/* 활성 탭 하이라이트 — 탭 사이를 미끄러지듯 이동. 행사 탭은 라우팅이라 인디케이터 없음. ponytail: 탭 4개 고정(w-1/4) */}
+      {/* 활성 탭 하이라이트 — 탭 사이를 미끄러지듯 이동. ponytail: 탭 4개 고정(w-1/4) */}
       <span
         aria-hidden="true"
         className="absolute inset-y-1.5 left-0 w-1/4 rounded-full bg-accent/12 transition-transform duration-300 ease-out motion-reduce:transition-none"
@@ -70,7 +69,7 @@ export function BottomNav({
       <Tab icon="list" label="목록" active={sheet === null} aria-current={sheet === null ? "page" : undefined} onClick={() => onSheet(null)} />
       <Tab icon="search" label="검색" active={sheet === "search"} badge={searchCount} aria-expanded={sheet === "search"} aria-controls="sheet-search" onClick={() => toggle("search")} />
       <Tab icon="filter" label="필터" active={sheet === "filter"} badge={filterCount} aria-expanded={sheet === "filter"} aria-controls="sheet-filter" onClick={() => toggle("filter")} />
-      <Tab icon="events" label="행사" aria-label="행사 목록" active={false} onClick={onEvents} />
+      <Tab icon="events" label="행사" active={sheet === "events"} aria-expanded={sheet === "events"} aria-controls="sheet-events" onClick={() => toggle("events")} />
     </nav>
   );
 }

--- a/src/components/Detail.tsx
+++ b/src/components/Detail.tsx
@@ -151,29 +151,32 @@ export function Detail({
           </div>
         </div>
 
-        <button
-          onClick={onToggle}
-          className={
-            "flex items-center justify-center gap-2 w-full h-[54px] mt-[26px] mb-6 rounded-2xl text-[15.5px] font-extrabold cursor-pointer border-0 text-white " +
-            (checked ? "bg-accent" : "bg-ink text-bg")
-          }
-        >
-          {checked && (
-            <svg
-              viewBox="0 0 24 24"
-              width="20"
-              height="20"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2.6"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <path d="M20 6L9 17l-5-5" />
-            </svg>
-          )}
-          <span>{checked ? "방문함" : "방문 체크"}</span>
-        </button>
+        {/* 방문 체크는 스크롤 없이 항상 보이도록 하단 고정 */}
+        <div className="sticky bottom-0 mt-[26px] pt-3 pb-[calc(24px+env(safe-area-inset-bottom))] bg-bg/95 backdrop-blur">
+          <button
+            onClick={onToggle}
+            className={
+              "flex items-center justify-center gap-2 w-full h-[54px] rounded-2xl text-[15.5px] font-extrabold cursor-pointer border-0 text-white " +
+              (checked ? "bg-accent" : "bg-ink text-bg")
+            }
+          >
+            {checked && (
+              <svg
+                viewBox="0 0 24 24"
+                width="20"
+                height="20"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2.6"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M20 6L9 17l-5-5" />
+              </svg>
+            )}
+            <span>{checked ? "방문함" : "방문 체크"}</span>
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -8,7 +8,8 @@ const EVENT_SECTIONS = [
   { status: "past", label: "지난 행사" },
 ] as const;
 
-function EventList({ events, currentSlug }: { events: ApiEvent[]; currentSlug: string | null }) {
+/** 행사 목록(진행 중/예정/지난). 데스크톱 사이드바와 모바일 행사 시트가 공유한다. */
+export function EventList({ events, currentSlug }: { events: ApiEvent[]; currentSlug: string | null }) {
   return EVENT_SECTIONS.map(({ status, label }) => {
     const matches = events
       .filter((event) => event.status === status)
@@ -33,7 +34,10 @@ function EventList({ events, currentSlug }: { events: ApiEvent[]; currentSlug: s
                   (current ? "border-accent/40 bg-accent/10" : "border-line bg-card md:bg-transparent md:hover:bg-chip")
                 }
               >
-                <div className={"text-[17px] font-extrabold md:text-sm " + (current ? "text-accent" : "text-ink")}>{candidate.title}</div>
+                <div className={"flex items-center gap-1.5 text-[17px] font-extrabold md:text-sm " + (current ? "text-accent" : "text-ink")}>
+                  {current ? <span aria-hidden="true">✓</span> : null}
+                  {candidate.title}
+                </div>
                 <div className="mt-1 text-xs font-semibold text-faint md:mt-0.5 md:text-[11px]">{eventSubtitle(candidate)}</div>
               </a>
             );

--- a/src/hooks/useAppRoute.ts
+++ b/src/hooks/useAppRoute.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { circleHash, eventHash, eventsHash, parseRoute, type AppRoute } from "../lib/route";
+import { circleHash, eventHash, parseRoute, type AppRoute } from "../lib/route";
 
 export function useAppRoute() {
   const [route, setRoute] = useState<AppRoute>(() => parseRoute(window.location.hash));
@@ -17,9 +17,7 @@ export function useAppRoute() {
 
   return {
     route,
-    openEvent: (slug: string) => navigate(eventHash(slug)),
     openCircle: (eventSlug: string, circleSlug: string) => navigate(circleHash(eventSlug, circleSlug)),
-    openEvents: () => navigate(eventsHash()),
     backToEvent: (eventSlug: string) => navigate(eventHash(eventSlug)),
   };
 }

--- a/test/client/App.test.tsx
+++ b/test/client/App.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { render, screen, fireEvent, cleanup, waitFor, act } from "@testing-library/react";
+import { render, screen, fireEvent, cleanup, waitFor, act, within } from "@testing-library/react";
 import App from "../../src/App";
 
 type ApiCircleLike = Record<string, unknown>;
@@ -251,7 +251,7 @@ describe("<App/> bottom navigation (mobile)", () => {
     vi.unstubAllGlobals();
   });
 
-  it("renders 4 tabs with 목록 as the current page and 행사 tab navigating to the root", async () => {
+  it("renders 4 tabs and opens the 행사 sheet without hiding the nav", async () => {
     render(<App />);
     await screen.findByText("부스서클");
     const nav = screen.getByRole("navigation", { name: "하단 메뉴" });
@@ -261,9 +261,52 @@ describe("<App/> bottom navigation (mobile)", () => {
     expect(indicator.style.transform).toBe("translateX(0%)");
     fireEvent.click(screen.getByRole("button", { name: "검색" }));
     expect(indicator.style.transform).toBe("translateX(100%)");
-    fireEvent.click(screen.getByRole("button", { name: "목록" }));
-    fireEvent.click(screen.getByRole("button", { name: "행사 목록" }));
-    await waitFor(() => expect(window.location.hash).toBe("#/"));
+
+    const eventsTab = screen.getByRole("button", { name: "행사" });
+    fireEvent.click(eventsTab);
+    expect(indicator.style.transform).toBe("translateX(300%)");
+    expect(eventsTab.getAttribute("aria-expanded")).toBe("true");
+    expect(eventsTab.getAttribute("aria-controls")).toBe("sheet-events");
+    const sheet = document.getElementById("sheet-events")!;
+    expect(sheet.className).toContain("md:hidden");
+    expect(document.activeElement).toBe(within(sheet).getByRole("link", { name: /코믹월드/ }));
+    expect(screen.getByRole("navigation", { name: "하단 메뉴" })).toBeTruthy();
+    expect(window.location.hash).toBe("#/events/ev");
+    // 현재 행사는 헤더 + 체크 표시
+    expect(within(sheet).getByRole("link", { name: /코믹월드/ }).getAttribute("aria-current")).toBe("page");
+
+    fireEvent.click(within(sheet).getByRole("link", { name: /일러스타 페스/ }));
+    await waitFor(() => expect(window.location.hash).toBe("#/events/illustar"));
+    await waitFor(() => expect(within(sheet).queryByRole("link", { name: /일러스타 페스/ })).toBeNull());
+    expect(eventsTab.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.getByRole("navigation", { name: "하단 메뉴" })).toBeTruthy();
+  });
+
+  it("closes the 행사 sheet with Escape, the backdrop, and re-tapping the current 행사", async () => {
+    render(<App />);
+    await screen.findByText("부스서클");
+    const tab = screen.getByRole("button", { name: "행사" });
+    const sheet = document.getElementById("sheet-events")!;
+    fireEvent.click(tab);
+    expect(document.body.style.overflow).toBe("hidden");
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(tab.getAttribute("aria-expanded")).toBe("false");
+    fireEvent.click(tab);
+    fireEvent.click(screen.getByRole("button", { name: "시트 닫기" }));
+    expect(tab.getAttribute("aria-expanded")).toBe("false");
+    fireEvent.click(tab);
+    fireEvent.click(within(sheet).getByRole("link", { name: /코믹월드/ })); // 같은 해시 → hashchange 없음
+    expect(tab.getAttribute("aria-expanded")).toBe("false");
+    expect(window.location.hash).toBe("#/events/ev");
+    expect(document.body.style.overflow).toBe("");
+    await act(() => new Promise((r) => setTimeout(r, 0))); // jsdom의 지연된 앵커 내비게이션이 다음 테스트로 새지 않게
+  });
+
+  it("shows the 행사 landing without a nav on direct #/events entry", async () => {
+    window.location.hash = "#/events";
+    render(<App />);
+    expect(await screen.findByRole("heading", { name: "행사 선택" })).toBeTruthy();
+    expect(screen.getByRole("link", { name: /코믹월드/ })).toBeTruthy();
     expect(screen.queryByRole("navigation", { name: "하단 메뉴" })).toBeNull();
   });
 

--- a/test/client/a11y-routing.test.tsx
+++ b/test/client/a11y-routing.test.tsx
@@ -45,7 +45,7 @@ describe("<App/> accessibility + routing", () => {
     render(<App />);
     await screen.findByText("부스서클");
     expect(screen.getByRole("searchbox", { name: "서클·부스·장르 검색" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "행사 목록" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "행사" })).toBeTruthy();
     expect(screen.getByRole("link", { name: "전체 부스배치도 (새 창)" }).getAttribute("target")).toBe("_blank");
     const allBtn = screen.getByRole("button", { name: "전체" });
     expect(allBtn.getAttribute("aria-pressed")).toBe("true");


### PR DESCRIPTION
## Summary
- \`Sheet\`에 \`"events"\` 추가. "행사" 탭은 \`toggle("events")\`, 렌즈 인디케이터가 4번째 칸으로 이동, \`aria-expanded\`/\`aria-controls="sheet-events"\`
- \`#sheet-events\`: 기존 \`EventList\`(진행 중/예정/지난) 재사용, 상단에 현재 행사 헤더, 현재 항목 ✓ + 강조. 항목 탭 시 시트 닫힘(현재 행사 재탭 포함)
- 시트는 검색/필터와 같은 패널 스타일(\`max-h-[75vh]\` 스크롤), md 이상은 사이드바가 담당하므로 \`md:hidden\`
- \`#/events\` 랜딩은 네비 없이 현행 유지. 서클 상세 네비 숨김 유지
- Detail "방문 체크" 버튼 \`sticky bottom\` 처리
- \`useAppRoute\`의 미사용 \`openEvent\`/\`openEvents\` 제거

Closes #42

## Test plan
- [x] 행사 탭 → 시트 열림, 네비 유지, 인디케이터 300%, 첫 항목 포커스
- [x] 항목 선택 → 해시 변경, 시트 닫힘, 목록 교체
- [x] 현재 행사 재탭 → 시트 닫힘, body overflow 해제
- [x] \`#/events\` 직접 진입 → 네비 없음, 행사 목록 표시
- [x] Escape/바깥 탭으로 닫힘
- [x] typecheck / vitest 83 passed / build