### PR TITLE
fix: 모바일 설정 메뉴 전환 및 행사 목록 하단바 보완

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ import { eventSubtitle } from "./lib/event";
 
 /* ---------- 앱 ---------- */
 export default function App() {
-  const { route, openCircle, backToEvent, openSettings } = useAppRoute();
+  const { route, openEvents, openEvent, openCircle, backToEvent, openSettings } = useAppRoute();
   const [events, setEvents] = useState<ApiEvent[]>([]);
   const [event, setEvent] = useState<ApiEvent | null>(null);
   const [authEnabled, setAuthEnabled] = useState(false);
@@ -26,7 +26,7 @@ export default function App() {
     if (merged > 0) setAnnounce(`${merged}개 항목을 동기화했어요`);
   }, []);
   const handleSyncError = useCallback(() => setAnnounce("방문 체크를 저장하지 못했어요"), []);
-  const [checks, toggle, reset] = useChecks(event?.slug ?? null, event?.status === "active", !!user, authLoading, handleSync, handleSyncError);
+  const [checks, toggle] = useChecks(event?.slug ?? null, event?.status === "active", !!user, authLoading, handleSync, handleSyncError);
   const [theme, setTheme] = useTheme();
   const [status, setStatus] = useState<Status>("all");
   const [selectedIps, setSelectedIps] = useState<string[]>([]);
@@ -34,6 +34,7 @@ export default function App() {
   const [announce, setAnnounce] = useState("");
   // 모바일 bottom sheet(검색/필터/행사/설정). 검색·필터는 md 이상에서 topbar에 인라인, 행사·설정은 사이드바가 대신한다.
   const [sheet, setSheet] = useState<Sheet>(null);
+  const pendingSheet = useRef<Exclude<Sheet, null> | null>(null);
   const searchRef = useRef<HTMLInputElement>(null);
 
   const [circles, setCircles] = useState<Circle[]>([]);
@@ -122,8 +123,13 @@ export default function App() {
     setQuery("");
   }, [requestedEventSlug]);
 
-  // 라우트가 바뀌면(상세 진입/행사 이동) 시트를 닫는다
-  useEffect(() => setSheet(null), [route]);
+  // 라우트가 바뀌면 시트를 닫는다. 설정에서 현재 행사로 이동한 경우에는
+  // 요청한 검색/필터 시트를 새 화면에서 다시 연다.
+  useEffect(() => {
+    const next = pendingSheet.current;
+    pendingSheet.current = null;
+    setSheet(next);
+  }, [route]);
 
   const opener = useRef<HTMLElement | null>(null);
   useEffect(() => {
@@ -175,8 +181,24 @@ export default function App() {
   const sheetCls = (s: Exclude<Sheet, null>) =>
     sheetPanel(s) + "md:static md:block md:translate-x-0 md:max-w-none md:rounded-none md:border-0 md:bg-transparent md:shadow-none md:backdrop-filter-none md:after:hidden md:p-0 md:max-h-none md:overflow-visible";
   const filterCount = (status === "all" ? 0 : 1) + selectedIps.length;
-  // 행사 랜딩(#/events)은 네비 없이 목록만, 서클 상세는 뒤로가기가 명확한 서브 화면
-  const showNav = route.kind !== "events" && !detailSlug;
+  const showNav = !detailSlug;
+  const openChecklistOrEvents = () => {
+    if (event?.slug) openEvent(event.slug);
+    else openEvents();
+  };
+  const handleNavSheet = (next: Sheet) => {
+    if (route.kind === "settings") {
+      if (next === "search" || next === "filter") {
+        if (!event?.slug) return openEvents();
+        pendingSheet.current = next;
+        openEvent(event.slug);
+        return;
+      }
+      if (next === "events") return openEvents();
+    }
+    if (route.kind !== "events") setSheet(next);
+  };
+  const navContext = route.kind === "settings" ? "settings" : route.kind === "events" ? "events" : "event";
 
   return (
     // 쉘: 모바일은 단일 컬럼(560px), md 이상은 사이드바 + 콘텐츠 2컬럼. 컴포넌트는 공유하고 레이아웃만 분기.
@@ -186,7 +208,7 @@ export default function App() {
       </div>
       <Sidebar
         events={events}
-        currentSlug={event?.slug ?? null}
+        currentSlug={(route.kind === "event" || route.kind === "circle") ? event?.slug ?? null : null}
         showOnMobile={route.kind === "events"}
         settingsActive={route.kind === "settings"}
         onSettings={openSettings}
@@ -195,7 +217,7 @@ export default function App() {
         {route.kind === "settings" ? (
           <div className="px-5 py-7 md:px-8 md:py-10">
             <h1 className="text-[26px] font-extrabold text-ink">설정</h1>
-            <div className="mt-7 max-w-[640px]"><Settings authEnabled={authEnabled} user={user} syncedAt={syncedAt} eventTitle={event?.title ?? null} theme={theme} onTheme={setTheme} onLogout={handleLogout} onReset={reset} /></div>
+            <div className="mt-7 max-w-[640px]"><Settings authEnabled={authEnabled} user={user} syncedAt={syncedAt} theme={theme} onTheme={setTheme} onLogout={handleLogout} /></div>
           </div>
         ) : route.kind === "events" ? (
           <div className="px-5 pt-7 pb-2 md:px-8 md:py-10">
@@ -447,7 +469,7 @@ export default function App() {
         )}
       </main>
       {showNav && (
-        <BottomNav sheet={sheet} onSheet={setSheet} searchCount={query ? 1 : 0} filterCount={filterCount} settingsActive={route.kind === "settings"} onSettings={openSettings} />
+        <BottomNav context={navContext} sheet={sheet} onSheet={handleNavSheet} onList={openChecklistOrEvents} onEvents={openEvents} searchCount={query ? 1 : 0} filterCount={filterCount} onSettings={openSettings} />
       )}
     </div>
   );

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -16,7 +16,7 @@ function Icon({ name }: { name: keyof typeof ICONS }) {
 }
 
 function Tab({
-  icon, label, active, badge, onClick, ...aria
+  icon, label, active, badge, onClick, disabled, ...aria
 }: {
   icon: keyof typeof ICONS;
   label: string;
@@ -27,11 +27,14 @@ function Tab({
   "aria-current"?: "page";
   "aria-expanded"?: boolean;
   "aria-controls"?: string;
+  "aria-disabled"?: boolean;
+  disabled?: boolean;
 }) {
   return (
     <button
       type="button"
       onClick={onClick}
+      disabled={disabled}
       aria-label={badge ? `${label} ${badge}개 적용` : undefined}
       {...aria}
       className={"relative flex flex-1 flex-col items-center justify-center gap-0.5 z-[1] min-h-[52px] min-w-[44px] rounded-full text-[11px] font-bold transition-colors " + (active ? "text-accent" : "text-muted")}
@@ -49,21 +52,25 @@ function Tab({
 
 /** 모바일 전용 하단 네비 — md 이상은 사이드바/topbar가 대신한다. */
 export function BottomNav({
-  sheet, onSheet, searchCount, filterCount, settingsActive, onSettings,
+  context, sheet, onSheet, onList, onEvents, searchCount, filterCount, onSettings,
 }: {
+  context: "event" | "events" | "settings";
   sheet: Sheet;
   onSheet: (next: Sheet) => void;
+  onList: () => void;
+  onEvents: () => void;
   searchCount: number;
   filterCount: number;
-  settingsActive: boolean;
   onSettings: () => void;
 }) {
+  const settingsActive = context === "settings";
   const toggle = (s: Exclude<Sheet, null>) => onSheet(sheet === s ? null : s);
-  const activeIndex = settingsActive ? 4 : sheet === "search" ? 1 : sheet === "filter" ? 2 : sheet === "events" ? 3 : 0;
+  const activeIndex = settingsActive ? 4 : context === "events" ? 3 : sheet === "search" ? 1 : sheet === "filter" ? 2 : sheet === "events" ? 3 : 0;
   const listActive = activeIndex === 0;
+  const sheetsDisabled = context === "events";
   return (
     <nav aria-label="하단 메뉴" className="glass glass-refract fixed left-1/2 -translate-x-1/2 w-[calc(100%-24px)] max-w-[536px] bottom-[calc(env(safe-area-inset-bottom)+12px)] z-30 flex rounded-full p-1.5 md:hidden">
-      {/* 렌즈 인디케이터 — 탭 사이를 액체처럼 미끄러진다. ponytail: 탭 4개 고정(w = (100%-패딩)/4) */}
+      {/* 렌즈 인디케이터 — 탭 사이를 액체처럼 미끄러진다. */}
       <span
         aria-hidden="true"
         className="glass-lens absolute inset-y-1.5 left-1.5 w-[calc(20%-3px)]"
@@ -71,10 +78,10 @@ export function BottomNav({
       >
         <span key={activeIndex} className="glass-lens-body block h-full w-full rounded-full" />
       </span>
-      <Tab icon="list" label="목록" active={listActive} aria-current={listActive ? "page" : undefined} onClick={() => onSheet(null)} />
-      <Tab icon="search" label="검색" active={sheet === "search"} badge={searchCount} aria-expanded={sheet === "search"} aria-controls="sheet-search" onClick={() => toggle("search")} />
-      <Tab icon="filter" label="필터" active={sheet === "filter"} badge={filterCount} aria-expanded={sheet === "filter"} aria-controls="sheet-filter" onClick={() => toggle("filter")} />
-      <Tab icon="events" label="행사" active={sheet === "events"} aria-expanded={sheet === "events"} aria-controls="sheet-events" onClick={() => toggle("events")} />
+      <Tab icon="list" label="목록" active={listActive} aria-current={listActive ? "page" : undefined} onClick={onList} />
+      <Tab icon="search" label="검색" active={sheet === "search"} badge={searchCount} aria-expanded={sheetsDisabled ? undefined : sheet === "search"} aria-controls={sheetsDisabled ? undefined : "sheet-search"} aria-disabled={sheetsDisabled || undefined} disabled={sheetsDisabled} onClick={() => { if (!sheetsDisabled) toggle("search"); }} />
+      <Tab icon="filter" label="필터" active={sheet === "filter"} badge={filterCount} aria-expanded={sheetsDisabled ? undefined : sheet === "filter"} aria-controls={sheetsDisabled ? undefined : "sheet-filter"} aria-disabled={sheetsDisabled || undefined} disabled={sheetsDisabled} onClick={() => { if (!sheetsDisabled) toggle("filter"); }} />
+      <Tab icon="events" label="행사" active={sheet === "events" || context === "events"} aria-current={context === "events" ? "page" : undefined} aria-expanded={context === "settings" ? undefined : sheet === "events"} aria-controls={context === "settings" ? undefined : "sheet-events"} onClick={() => { if (context === "settings") onEvents(); else if (context !== "events") toggle("events"); }} />
       <Tab icon="list" label="설정" active={settingsActive} aria-current={settingsActive ? "page" : undefined} onClick={onSettings} />
     </nav>
   );

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -60,27 +60,23 @@ const rowCls = "flex w-full items-center gap-2 rounded-[10px] px-3 py-2.5 text-l
 const primaryBtn = "inline-flex h-9 items-center rounded-full bg-ink px-4 text-[13px] font-bold text-bg";
 
 /**
- * 설정 패널(#45): 기기 간 연동 · 화면 · 데이터 · 정보.
+ * 설정 패널(#45): 기기 간 연동 · 화면 · 정보.
  * 모바일 시트와 데스크톱 사이드바 <details>가 같은 컴포넌트를 감싼다 — DOM id를 두지 않는다(두 사본 공존).
  */
 export function Settings({
   authEnabled,
   user,
   syncedAt,
-  eventTitle,
   theme,
   onTheme,
   onLogout,
-  onReset,
 }: {
   authEnabled: boolean;
   user: AuthUser | null;
   syncedAt: number | null;
-  eventTitle: string | null;
   theme: Theme;
   onTheme: (next: Theme) => void;
   onLogout: () => void;
-  onReset: () => void;
 }) {
 
   const displayName = user?.name ?? user?.email ?? "사용자";
@@ -135,20 +131,6 @@ export function Settings({
           ))}
         </div>
       </section>
-
-      {/* 초기화 대상 행사가 없으면(행사 선택 화면) 섹션 자체를 숨긴다 — confirm 후 무반응 방지 */}
-      {eventTitle ? (
-        <section className="grid gap-2.5">
-          <h3 className={headingCls}>데이터</h3>
-          <button
-            type="button"
-            onClick={() => { if (confirm(`${eventTitle}의 방문 체크를 모두 지울까요?`)) onReset(); }}
-            className={rowCls + "border border-line bg-card text-danger hover:bg-danger/10"}
-          >
-            이 행사 방문 체크 초기화
-          </button>
-        </section>
-      ) : null}
 
       <section className="grid gap-2.5">
         <h3 className={headingCls}>정보</h3>

--- a/src/hooks/useAppRoute.ts
+++ b/src/hooks/useAppRoute.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { circleHash, eventHash, parseRoute, settingsHash, type AppRoute } from "../lib/route";
+import { circleHash, eventHash, eventsHash, parseRoute, settingsHash, type AppRoute } from "../lib/route";
 
 export function useAppRoute() {
   const [route, setRoute] = useState<AppRoute>(() => parseRoute(window.location.hash));
@@ -15,10 +15,13 @@ export function useAppRoute() {
     setRoute(parseRoute(hash));
   };
 
+  const openEvent = (eventSlug: string) => navigate(eventHash(eventSlug));
   return {
     route,
+    openEvents: () => navigate(eventsHash()),
+    openEvent,
     openCircle: (eventSlug: string, circleSlug: string) => navigate(circleHash(eventSlug, circleSlug)),
-    backToEvent: (eventSlug: string) => navigate(eventHash(eventSlug)),
+    backToEvent: openEvent,
     openSettings: () => navigate(settingsHash()),
   };
 }

--- a/src/hooks/useChecks.ts
+++ b/src/hooks/useChecks.ts
@@ -15,7 +15,7 @@ export function useChecks(
   authLoading = false,
   onSync?: (mergedCount: number) => void,
   onSyncError?: () => void,
-): [Checks, (id: string) => void, () => void] {
+): [Checks, (id: string) => void] {
   const [checks, setChecks] = useState<Checks>({});
   const cb = useRef({ onSync, onSyncError });
   useEffect(() => { cb.current = { onSync, onSyncError }; });
@@ -53,10 +53,5 @@ export function useChecks(
       return next;
     });
 
-  const reset = () => {
-    persist({});
-    setChecks({});
-  };
-
-  return [checks, toggle, reset];
+  return [checks, toggle];
 }

--- a/test/client/App.test.tsx
+++ b/test/client/App.test.tsx
@@ -167,27 +167,12 @@ describe("<App/> confirmed + unlisted", () => {
     expect(screen.getAllByLabelText("방문 체크 해제").length).toBe(2); // 원격 booth1 + 로컬 tsuhan1 모두 유지
   });
 
-  it("hides the reset action on the 행사 landing where there is nothing to reset (#45)", async () => {
+  it("does not render the removed visit reset action", async () => {
     window.location.hash = "#/events";
     render(<App />);
     await screen.findByRole("heading", { name: "행사 선택" });
     openSidebarSettings();
     expect(screen.queryByRole("button", { name: "이 행사 방문 체크 초기화" })).toBeNull();
-  });
-
-  it("clears the current 행사 checks from settings after confirm (#45)", async () => {
-    window.location.hash = "#/events/ev";
-    localStorage.setItem("gbc-seoko-checks:ev", JSON.stringify({ booth1: true }));
-    render(<App />);
-    await screen.findByText("부스서클");
-    expect(screen.getAllByLabelText("방문 체크 해제").length).toBe(1);
-    const settings = openSidebarSettings();
-    const confirm = vi.spyOn(window, "confirm").mockReturnValue(false);
-    fireEvent.click(settings.getByRole("button", { name: "이 행사 방문 체크 초기화" }));
-    confirm.mockReturnValue(true);
-    fireEvent.click(settings.getByRole("button", { name: "이 행사 방문 체크 초기화" }));
-    await waitFor(() => expect(screen.queryByLabelText("방문 체크 해제")).toBeNull());
-    expect(localStorage.getItem("gbc-seoko-checks:ev")).toBe("{}");
   });
 
   it("still signs out locally when the logout request fails (#34)", async () => {
@@ -406,12 +391,43 @@ describe("<App/> bottom navigation (mobile)", () => {
     expect(document.activeElement).toBe(gear);
   });
 
-  it("shows the 행사 landing without a nav on direct #/events entry", async () => {
+  it("shows the 행사 landing with a nav and disables irrelevant actions", async () => {
     window.location.hash = "#/events";
     render(<App />);
     expect(await screen.findByRole("heading", { name: "행사 선택" })).toBeTruthy();
     expect(screen.getByRole("link", { name: /코믹월드/ })).toBeTruthy();
-    expect(screen.queryByRole("navigation", { name: "하단 메뉴" })).toBeNull();
+    const nav = screen.getByRole("navigation", { name: "하단 메뉴" });
+    expect(screen.getByRole("button", { name: "행사" }).getAttribute("aria-current")).toBe("page");
+    expect(nav.querySelector('button[aria-disabled="true"]')).toBeTruthy();
+  });
+
+  it("clears the selected 행사 when opening the landing from a checklist", async () => {
+    window.location.hash = "#/events/ev";
+    render(<App />);
+    await screen.findByText("부스서클");
+    fireEvent.click(screen.getByRole("button", { name: "설정" }));
+    fireEvent.click(screen.getByRole("button", { name: "행사" }));
+    await screen.findByRole("heading", { name: "행사 선택" });
+    expect(screen.getByRole("link", { name: /코믹월드/ }).getAttribute("aria-current")).toBeNull();
+  });
+
+  it("connects settings navigation to the current checklist", async () => {
+    window.location.hash = "#/events/ev";
+    render(<App />);
+    await screen.findByText("부스서클");
+    fireEvent.click(screen.getByRole("button", { name: "설정" }));
+    expect(await screen.findByRole("heading", { name: "설정" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "행사" }));
+    expect(await screen.findByRole("heading", { name: "행사 선택" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("link", { name: /코믹월드/ }));
+    expect(await screen.findByText("부스서클")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "설정" }));
+    fireEvent.click(screen.getByRole("button", { name: "목록" }));
+    expect(await screen.findByText("부스서클")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "설정" }));
+    fireEvent.click(screen.getByRole("button", { name: "검색" }));
+    expect(await screen.findByRole("searchbox")).toBeTruthy();
+    expect(window.location.hash).toBe("#/events/ev");
   });
 
   it("toggles the search/filter sheets and shows the active filter count", async () => {

--- a/test/client/Settings.test.tsx
+++ b/test/client/Settings.test.tsx
@@ -11,7 +11,7 @@ import { login } from "../../src/api";
 
 const USER = { userId: "u1", email: "seoko@example.com", name: "세오코", avatarUrl: null };
 const noop = () => {};
-const base = { authEnabled: true, user: null, syncedAt: null, eventTitle: "코믹월드", theme: "system" as const, onTheme: noop, onLogout: noop, onReset: noop };
+const base = { authEnabled: true, user: null, syncedAt: null, theme: "system" as const, onTheme: noop, onLogout: noop };
 
 /** 실제 배선과 동일 — 테마 상태는 부모(App)의 useTheme가 들고 내려준다 */
 function Themed(props: Partial<Parameters<typeof Settings>[0]>) {
@@ -35,7 +35,7 @@ describe("<Settings/>", () => {
     expect(screen.queryByRole("button", { name: "연동 해제" })).toBeNull();
     expect(screen.queryByText("기기 간 연동")).toBeNull();
     expect(screen.getByRole("group", { name: "테마" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "이 행사 방문 체크 초기화" })).toBeTruthy();
+    expect(screen.queryByText("데이터")).toBeNull();
     expect(screen.getByText(/앱 버전/)).toBeTruthy();
     expect(screen.getByRole("link", { name: /문의·피드백/ }).getAttribute("href")).toBe("https://github.com/bini59/317_gbc_seoko/issues");
   });
@@ -70,12 +70,6 @@ describe("<Settings/>", () => {
     expect(document.querySelector("img")?.getAttribute("src")).toBe("https://cdn.example/a.png");
   });
 
-  it("hides the 데이터 section when there is no current 행사 (reset would be a no-op)", () => {
-    render(<Settings {...base} eventTitle={null} />);
-    expect(screen.queryByText("데이터")).toBeNull();
-    expect(screen.queryByRole("button", { name: "이 행사 방문 체크 초기화" })).toBeNull();
-  });
-
   it("theme segment writes data-theme + localStorage and 시스템 clears the attribute", () => {
     render(<Themed />);
     expect(screen.getByRole("button", { name: "시스템" }).getAttribute("aria-pressed")).toBe("true");
@@ -94,15 +88,4 @@ describe("<Settings/>", () => {
     expect(screen.getByRole("button", { name: "라이트" }).getAttribute("aria-pressed")).toBe("true");
   });
 
-  it("reset asks confirm(); cancel does nothing, ok calls onReset", () => {
-    const onReset = vi.fn();
-    const confirm = vi.spyOn(window, "confirm").mockReturnValue(false);
-    render(<Settings {...base} onReset={onReset} />);
-    fireEvent.click(screen.getByRole("button", { name: "이 행사 방문 체크 초기화" }));
-    expect(onReset).not.toHaveBeenCalled();
-    confirm.mockReturnValue(true);
-    fireEvent.click(screen.getByRole("button", { name: "이 행사 방문 체크 초기화" }));
-    expect(onReset).toHaveBeenCalledTimes(1);
-    expect(confirm).toHaveBeenLastCalledWith("코믹월드의 방문 체크를 모두 지울까요?");
-  });
 });


### PR DESCRIPTION
## 변경 사항
- 모바일 설정 화면의 하단 네비게이션을 목록·검색·필터·행사 화면 전환과 연결
- 행사 목록 화면에 모바일 하단 네비게이션 추가
- 행사 목록에서 의미 없는 검색·필터를 비활성화하고 접근성 상태 명시
- 설정의 `이 행사 방문 체크 초기화` UI와 관련 상태/테스트 제거
- 해시 라우팅 및 이전 행사 선택 상태 회귀 테스트 추가

## 검증
- `npm test`
- `npm run typecheck`
- `npm run build`
- `git diff --check`

Closes #49
