### PR TITLE
fix: 모바일 메뉴 상태 및 설정 렌더링 정리 (#51)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,7 +32,7 @@ export default function App() {
   const [selectedIps, setSelectedIps] = useState<string[]>([]);
   const [query, setQuery] = useState("");
   const [announce, setAnnounce] = useState("");
-  // 모바일 bottom sheet(검색/필터/행사/설정). 검색·필터는 md 이상에서 topbar에 인라인, 행사·설정은 사이드바가 대신한다.
+  // 모바일 bottom sheet(검색/필터/행사). 설정은 항상 독립 라우트로 렌더링한다.
   const [sheet, setSheet] = useState<Sheet>(null);
   const pendingSheet = useRef<Exclude<Sheet, null> | null>(null);
   const searchRef = useRef<HTMLInputElement>(null);
@@ -173,9 +173,12 @@ export default function App() {
     (active ? "bg-accent/10 text-accent border-accent/30" : "bg-card text-muted border-line");
   // 상세 패널이 열리면 xl에서도 2열 유지(목록 폭이 줄어듦)
   const gridCls = "grid gap-3 md:grid-cols-2 " + (detail ? "" : "xl:grid-cols-3");
+  // 시트는 행사 체크리스트에서만 존재한다. 라우트 전환 직후의 이전 상태가
+  // 설정/행사 목록 화면에 한 프레임이라도 남지 않도록 렌더 경계를 둔다.
+  const visibleSheet = route.kind === "event" ? sheet : null;
   // 모바일: 시트가 열렸을 때만 하단 패널로 노출(네비 높이만큼 위). md 이상: topbar 인라인.
   const sheetPanel = (s: Exclude<Sheet, null>) =>
-    sheet === s
+    visibleSheet === s
       ? "glass fixed left-1/2 -translate-x-1/2 w-full max-w-[560px] bottom-0 z-20 rounded-t-[28px] border-b-0 px-5 pt-5 pb-[calc(92px+env(safe-area-inset-bottom))] max-h-[75vh] overflow-y-auto "
       : "hidden ";
   const sheetCls = (s: Exclude<Sheet, null>) =>
@@ -259,7 +262,7 @@ export default function App() {
                   </div>
                 </div>
 
-                {sheet ? <button type="button" aria-label="시트 닫기" onClick={() => setSheet(null)} className="fixed inset-0 z-20 bg-black/40 md:hidden" /> : null}
+                {visibleSheet ? <button type="button" aria-label="시트 닫기" onClick={() => setSheet(null)} className="fixed inset-0 z-20 bg-black/40 md:hidden" /> : null}
 
                 <div id="sheet-search" role="group" aria-label="검색" className={sheetCls("search")}>
                 <div className="flex items-center gap-2.5 h-12 bg-card border border-line rounded-[14px] px-3.5 md:h-10 md:max-w-[520px]">
@@ -381,13 +384,12 @@ export default function App() {
                   ) : null}
                 </div>
 
-                {/* 설정 시트(#45) — 열릴 때만 렌더(사이드바 사본과 중복 방지). md 이상은 사이드바 <details>가 담당 */}
               </div>
 
               <div className="px-[22px] pt-3.5 pb-2 text-[12.5px] font-bold text-faint md:px-8">참가 서클 {filtered.length}곳</div>
 
               {/* 카드 목록 — 데스크톱은 2~3열 그리드 */}
-              <div className="px-5 md:px-8" {...(sheet ? { inert: "" } : {})}>
+              <div className="px-5 md:px-8" {...(visibleSheet ? { inert: "" } : {})}>
                 {loadError && (
                   <div className="text-center py-14" role="alert">
                     <div className="text-danger text-sm font-semibold">{loadError}</div>
@@ -469,7 +471,7 @@ export default function App() {
         )}
       </main>
       {showNav && (
-        <BottomNav context={navContext} sheet={sheet} onSheet={handleNavSheet} onList={openChecklistOrEvents} onEvents={openEvents} searchCount={query ? 1 : 0} filterCount={filterCount} onSettings={openSettings} />
+        <BottomNav context={navContext} sheet={visibleSheet} onSheet={handleNavSheet} onList={openChecklistOrEvents} onEvents={openEvents} searchCount={query ? 1 : 0} filterCount={filterCount} onSettings={openSettings} />
       )}
     </div>
   );

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -5,6 +5,7 @@ const ICONS = {
   search: <><circle cx="11" cy="11" r="7" /><path d="M21 21l-4-4" /></>,
   filter: <><path d="M4 7h16M7 12h10M10 17h4" /></>,
   events: <><rect x="3" y="5" width="18" height="16" rx="2" /><path d="M3 10h18M8 3v4M16 3v4" /></>,
+  settings: <><circle cx="12" cy="12" r="3" /><path d="M19.4 15a1.7 1.7 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.7 1.7 0 0 0-1.8-.3 1.7 1.7 0 0 0-1 1.5V21a2 2 0 1 1-4 0v-.1a1.7 1.7 0 0 0-1.1-1.5 1.7 1.7 0 0 0-1.8.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.7 1.7 0 0 0 .3-1.8 1.7 1.7 0 0 0-1.5-1H3a2 2 0 1 1 0-4h.1a1.7 1.7 0 0 0 1.5-1.1 1.7 1.7 0 0 0-.3-1.8l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.7 1.7 0 0 0 1.8.3H9a1.7 1.7 0 0 0 1-1.5V3a2 2 0 1 1 4 0v.1a1.7 1.7 0 0 0 1 1.5 1.7 1.7 0 0 0 1.8-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.7 1.7 0 0 0-.3 1.8V9a1.7 1.7 0 0 0 1.5 1H21a2 2 0 1 1 0 4h-.1a1.7 1.7 0 0 0-1.5 1z" /></>,
 };
 
 function Icon({ name }: { name: keyof typeof ICONS }) {
@@ -37,7 +38,7 @@ function Tab({
       disabled={disabled}
       aria-label={badge ? `${label} ${badge}개 적용` : undefined}
       {...aria}
-      className={"relative flex flex-1 flex-col items-center justify-center gap-0.5 z-[1] min-h-[52px] min-w-[44px] rounded-full text-[11px] font-bold transition-colors " + (active ? "text-accent" : "text-muted")}
+      className={"relative flex flex-1 flex-col items-center justify-center gap-0.5 z-[1] min-h-[52px] min-w-[44px] rounded-full text-[11px] font-bold transition-colors " + (disabled ? "cursor-not-allowed text-muted opacity-50" : active ? "cursor-pointer text-accent" : "cursor-pointer text-muted")}
     >
       <Icon name={icon} />
       {label}
@@ -68,6 +69,7 @@ export function BottomNav({
   const activeIndex = settingsActive ? 4 : context === "events" ? 3 : sheet === "search" ? 1 : sheet === "filter" ? 2 : sheet === "events" ? 3 : 0;
   const listActive = activeIndex === 0;
   const sheetsDisabled = context === "events";
+  const listDisabled = context === "events";
   return (
     <nav aria-label="하단 메뉴" className="glass glass-refract fixed left-1/2 -translate-x-1/2 w-[calc(100%-24px)] max-w-[536px] bottom-[calc(env(safe-area-inset-bottom)+12px)] z-30 flex rounded-full p-1.5 md:hidden">
       {/* 렌즈 인디케이터 — 탭 사이를 액체처럼 미끄러진다. */}
@@ -78,11 +80,11 @@ export function BottomNav({
       >
         <span key={activeIndex} className="glass-lens-body block h-full w-full rounded-full" />
       </span>
-      <Tab icon="list" label="목록" active={listActive} aria-current={listActive ? "page" : undefined} onClick={onList} />
-      <Tab icon="search" label="검색" active={sheet === "search"} badge={searchCount} aria-expanded={sheetsDisabled ? undefined : sheet === "search"} aria-controls={sheetsDisabled ? undefined : "sheet-search"} aria-disabled={sheetsDisabled || undefined} disabled={sheetsDisabled} onClick={() => { if (!sheetsDisabled) toggle("search"); }} />
-      <Tab icon="filter" label="필터" active={sheet === "filter"} badge={filterCount} aria-expanded={sheetsDisabled ? undefined : sheet === "filter"} aria-controls={sheetsDisabled ? undefined : "sheet-filter"} aria-disabled={sheetsDisabled || undefined} disabled={sheetsDisabled} onClick={() => { if (!sheetsDisabled) toggle("filter"); }} />
-      <Tab icon="events" label="행사" active={sheet === "events" || context === "events"} aria-current={context === "events" ? "page" : undefined} aria-expanded={context === "settings" ? undefined : sheet === "events"} aria-controls={context === "settings" ? undefined : "sheet-events"} onClick={() => { if (context === "settings") onEvents(); else if (context !== "events") toggle("events"); }} />
-      <Tab icon="list" label="설정" active={settingsActive} aria-current={settingsActive ? "page" : undefined} onClick={onSettings} />
+      <Tab icon="list" label="목록" active={listActive} aria-current={listActive ? "page" : undefined} aria-disabled={listDisabled || undefined} disabled={listDisabled} onClick={onList} />
+      <Tab icon="search" label="검색" active={sheet === "search"} badge={searchCount} aria-current={sheet === "search" ? "page" : undefined} aria-expanded={sheetsDisabled ? undefined : sheet === "search"} aria-controls={sheetsDisabled ? undefined : "sheet-search"} aria-disabled={sheetsDisabled || undefined} disabled={sheetsDisabled} onClick={() => { if (!sheetsDisabled) toggle("search"); }} />
+      <Tab icon="filter" label="필터" active={sheet === "filter"} badge={filterCount} aria-current={sheet === "filter" ? "page" : undefined} aria-expanded={sheetsDisabled ? undefined : sheet === "filter"} aria-controls={sheetsDisabled ? undefined : "sheet-filter"} aria-disabled={sheetsDisabled || undefined} disabled={sheetsDisabled} onClick={() => { if (!sheetsDisabled) toggle("filter"); }} />
+      <Tab icon="events" label="행사" active={sheet === "events" || context === "events"} aria-current={sheet === "events" || context === "events" ? "page" : undefined} aria-expanded={context === "settings" ? undefined : sheet === "events"} aria-controls={context === "settings" ? undefined : "sheet-events"} onClick={() => { if (context === "settings") onEvents(); else if (context !== "events") toggle("events"); }} />
+      <Tab icon="settings" label="설정" active={settingsActive} aria-current={settingsActive ? "page" : undefined} onClick={onSettings} />
     </nav>
   );
 }

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -60,8 +60,8 @@ const rowCls = "flex w-full items-center gap-2 rounded-[10px] px-3 py-2.5 text-l
 const primaryBtn = "inline-flex h-9 items-center rounded-full bg-ink px-4 text-[13px] font-bold text-bg";
 
 /**
- * 설정 패널(#45): 기기 간 연동 · 화면 · 정보.
- * 모바일 시트와 데스크톱 사이드바 <details>가 같은 컴포넌트를 감싼다 — DOM id를 두지 않는다(두 사본 공존).
+ * 독립 설정 페이지(#51): 기기 간 연동 · 화면 · 정보.
+ * 설정은 하단 시트나 화면 내부 진입점 없이 `#/settings`에서만 렌더링한다.
  */
 export function Settings({
   authEnabled,

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -77,7 +77,7 @@ export function Sidebar({
       <nav aria-label="행사" className="flex-1 px-5 pb-6">
         <EventList events={events} currentSlug={currentSlug} />
       </nav>
-      <div className="border-t border-line px-5 py-4">
+      <div className={(showOnMobile ? "hidden md:block " : "") + "border-t border-line px-5 py-4"}>
         <a href="#/settings" onClick={(e) => { e.preventDefault(); onSettings(); }} aria-current={settingsActive ? "page" : undefined} className={(settingsActive ? "bg-accent/10 text-accent " : "text-muted ") + "flex items-center gap-2 rounded-[10px] px-3 py-2.5 text-xs font-semibold no-underline hover:bg-chip hover:text-ink"}>
           <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
             <circle cx="12" cy="12" r="3" /><path d="M19.4 15a1.7 1.7 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.7 1.7 0 0 0-1.8-.3 1.7 1.7 0 0 0-1 1.5V21a2 2 0 1 1-4 0v-.1a1.7 1.7 0 0 0-1.1-1.5 1.7 1.7 0 0 0-1.8.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.7 1.7 0 0 0 .3-1.8 1.7 1.7 0 0 0-1.5-1H3a2 2 0 1 1 0-4h.1a1.7 1.7 0 0 0 1.5-1.1 1.7 1.7 0 0 0-.3-1.8l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.7 1.7 0 0 0 1.8.3H9a1.7 1.7 0 0 0 1-1.5V3a2 2 0 1 1 4 0v.1a1.7 1.7 0 0 0 1 1.5 1.7 1.7 0 0 0 1.8-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.7 1.7 0 0 0-.3 1.8V9a1.7 1.7 0 0 0 1.5 1H21a2 2 0 1 1 0 4h-.1a1.7 1.7 0 0 0-1.5 1z" />

--- a/test/client/App.test.tsx
+++ b/test/client/App.test.tsx
@@ -396,9 +396,17 @@ describe("<App/> bottom navigation (mobile)", () => {
     render(<App />);
     expect(await screen.findByRole("heading", { name: "행사 선택" })).toBeTruthy();
     expect(screen.getByRole("link", { name: /코믹월드/ })).toBeTruthy();
+    expect(within(screen.getByRole("complementary")).getByRole("link", { name: "설정" }).parentElement?.classList.contains("hidden")).toBe(true);
     const nav = screen.getByRole("navigation", { name: "하단 메뉴" });
     expect(screen.getByRole("button", { name: "행사" }).getAttribute("aria-current")).toBe("page");
-    expect(nav.querySelector('button[aria-disabled="true"]')).toBeTruthy();
+    const unavailable = [screen.getByRole("button", { name: "목록" }), screen.getByRole("button", { name: "검색" }), screen.getByRole("button", { name: "필터" })];
+    for (const tab of unavailable) {
+      expect((tab as HTMLButtonElement).disabled).toBe(true);
+      expect(tab.getAttribute("aria-disabled")).toBe("true");
+      expect(tab.className).toContain("cursor-not-allowed");
+      expect(tab.className).toContain("opacity");
+    }
+    expect(nav.querySelectorAll('button[aria-disabled="true"]').length).toBe(3);
   });
 
   it("clears the selected 행사 when opening the landing from a checklist", async () => {
@@ -438,6 +446,7 @@ describe("<App/> bottom navigation (mobile)", () => {
     search.focus(); // 실제 브라우저에서는 탭 클릭이 포커스를 옮긴다 — 시트 닫힘 후 포커스 복원 검증용
     fireEvent.click(search);
     expect(search.getAttribute("aria-expanded")).toBe("true");
+    expect(search.getAttribute("aria-current")).toBe("page");
     expect(document.getElementById("sheet-search")!.classList.contains("hidden")).toBe(false);
     expect(document.activeElement).toBe(screen.getByRole("searchbox"));
     fireEvent.change(screen.getByRole("searchbox"), { target: { value: "부스" } });
@@ -449,7 +458,9 @@ describe("<App/> bottom navigation (mobile)", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "필터" }));
     expect(search.getAttribute("aria-expanded")).toBe("false");
+    expect(search.getAttribute("aria-current")).toBeNull();
     expect(screen.getByRole("button", { name: "필터" }).getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByRole("button", { name: "필터" }).getAttribute("aria-current")).toBe("page");
     fireEvent.click(screen.getByRole("button", { name: "체크함" }));
     fireEvent.click(screen.getByRole("button", { name: "걸즈밴드크라이" }));
     expect(screen.getByRole("button", { name: "필터 2개 적용" })).toBeTruthy();
@@ -468,5 +479,17 @@ describe("<App/> bottom navigation (mobile)", () => {
     fireEvent.click(await screen.findByText("부스서클"));
     expect(screen.getByText("서클 상세")).toBeTruthy();
     expect(screen.queryByRole("navigation", { name: "하단 메뉴" })).toBeNull();
+  });
+
+  it("does not carry an open sheet into circle detail", async () => {
+    render(<App />);
+    await screen.findByText("부스서클");
+    fireEvent.click(screen.getByRole("button", { name: "검색" }));
+    expect(screen.getByRole("group", { name: "검색" }).classList.contains("hidden")).toBe(false);
+
+    fireEvent.click(screen.getByText("부스서클"));
+    expect(await screen.findByText("서클 상세")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "시트 닫기" })).toBeNull();
+    expect(screen.getByRole("group", { name: "검색" }).classList.contains("hidden")).toBe(true);
   });
 });


### PR DESCRIPTION
## 변경 사항
- 행사 선택 화면에서 사용할 수 없는 목록·검색·필터 탭을 네이티브 `disabled`와 시각적 비활성 상태로 일치시킴
- 하단 네비게이션의 활성 탭에 `aria-current`를 반영하고 설정 아이콘을 분리함
- 행사 선택 화면의 모바일 Sidebar 설정 링크를 숨겨 하단 네비게이션과의 중복 노출을 제거함
- 체크리스트 외 라우트에서 이전 검색/필터/행사 시트가 보이지 않도록 렌더링 경계를 추가함
- 모바일 메뉴·접근성·라우팅 회귀 테스트 추가/보강

## 검증
- `npm test`
- `npm run typecheck`
- `npm run build`
- `git diff --check`

Closes #51
