### PR TITLE
feat: 설정 화면 하단에 로그아웃 버튼 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -215,7 +215,7 @@ export default function App() {
       />
       <main className={"w-full max-w-[560px] mx-auto border-x border-line md:max-w-none md:mx-0 md:border-x-0 md:min-h-screen " + (route.kind === "events" ? "" : "flex-1")}>
         {route.kind === "settings" ? (
-          <div className="px-5 py-7 md:px-8 md:py-10">
+          <div className="px-5 pt-7 pb-[calc(88px+env(safe-area-inset-bottom))] md:px-8 md:py-10">
             <h1 className="text-[26px] font-extrabold text-ink">설정</h1>
             <div className="mt-7 max-w-[640px]"><Settings authEnabled={authEnabled} user={user} syncedAt={syncedAt} theme={theme} onTheme={setTheme} onLogout={handleLogout} /></div>
           </div>

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -103,7 +103,6 @@ export function Settings({
                   <span>계정센터<span className="sr-only"> (새 창)</span></span>
                   <External />
                 </a>
-                <button type="button" onClick={onLogout} className={rowCls + "text-danger hover:bg-danger/10"}>연동 해제</button>
               </div>
             </div>
           ) : (
@@ -142,6 +141,15 @@ export function Settings({
           </a>
         </div>
       </section>
+
+      {authEnabled && user ? (
+        <section className="grid gap-2.5">
+          <h3 className={headingCls}>계정</h3>
+          <div className="rounded-[14px] border border-line bg-card p-1.5">
+            <button type="button" onClick={onLogout} className={rowCls + "text-danger hover:bg-danger/10"}>로그아웃</button>
+          </div>
+        </section>
+      ) : null}
     </div>
   );
 }

--- a/test/client/App.test.tsx
+++ b/test/client/App.test.tsx
@@ -107,13 +107,13 @@ describe("<App/> confirmed + unlisted", () => {
     expect(screen.queryByRole("button", { name: "로그인" })).toBeNull();
   });
 
-  it("keeps name/logout in the sidebar settings only when signed in (#30)", async () => {
+  it("keeps name/logout in the sidebar settings only when signed in (#52)", async () => {
     window.location.hash = "#/events/ev";
     mockApi(CIRCLES, true, { userId: "u1", email: null, name: "세오코", avatarUrl: null });
     render(<App />);
     await screen.findByText("부스서클");
     const settings = openSidebarSettings();
-    expect(await settings.findByRole("button", { name: "연동 해제" })).toBeTruthy();
+    expect(await settings.findByRole("button", { name: "로그아웃" })).toBeTruthy();
     expect(settings.getByText("세오코")).toBeTruthy();
     expect(screen.queryByRole("button", { name: "연동하기" })).toBeNull();
     expect(screen.queryByRole("button", { name: "로그인" })).toBeNull();
@@ -125,10 +125,10 @@ describe("<App/> confirmed + unlisted", () => {
     render(<App />);
     await screen.findByText("부스서클");
     const settings = openSidebarSettings();
-    fireEvent.click(await settings.findByRole("button", { name: "연동 해제" }));
+    fireEvent.click(await settings.findByRole("button", { name: "로그아웃" }));
     expect(await settings.findByRole("button", { name: "연동하기" })).toBeTruthy();
     expect(vi.mocked(fetch)).toHaveBeenCalledWith("/api/auth/logout", { method: "POST", credentials: "include" });
-    expect(screen.queryByRole("button", { name: "연동 해제" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "로그아웃" })).toBeNull();
   });
 
   it("announces the merged count after the first remote sync (#45)", async () => {
@@ -186,7 +186,7 @@ describe("<App/> confirmed + unlisted", () => {
     render(<App />);
     await screen.findByText("부스서클");
     const settings = openSidebarSettings();
-    fireEvent.click(await settings.findByRole("button", { name: "연동 해제" }));
+    fireEvent.click(await settings.findByRole("button", { name: "로그아웃" }));
     expect(await settings.findByRole("button", { name: "연동하기" })).toBeTruthy();
   });
 
@@ -417,6 +417,7 @@ describe("<App/> bottom navigation (mobile)", () => {
     await screen.findByText("부스서클");
     fireEvent.click(screen.getByRole("button", { name: "설정" }));
     expect(await screen.findByRole("heading", { name: "설정" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "설정" }).parentElement?.className).toContain("pb-[calc(88px+env(safe-area-inset-bottom))]");
     fireEvent.click(screen.getByRole("button", { name: "행사" }));
     expect(await screen.findByRole("heading", { name: "행사 선택" })).toBeTruthy();
     fireEvent.click(screen.getByRole("link", { name: /코믹월드/ }));

--- a/test/client/Settings.test.tsx
+++ b/test/client/Settings.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
-import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { render, screen, fireEvent, cleanup, within } from "@testing-library/react";
 import { Settings, useTheme } from "../../src/components/Settings";
 
 vi.mock("../../src/api", async (importOriginal) => ({
@@ -32,7 +32,7 @@ describe("<Settings/>", () => {
   it("hides the sync section entirely when auth is disabled but keeps 화면/데이터/정보", () => {
     render(<Settings {...base} authEnabled={false} />);
     expect(screen.queryByRole("button", { name: "연동하기" })).toBeNull();
-    expect(screen.queryByRole("button", { name: "연동 해제" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "로그아웃" })).toBeNull();
     expect(screen.queryByText("기기 간 연동")).toBeNull();
     expect(screen.getByRole("group", { name: "테마" })).toBeTruthy();
     expect(screen.queryByText("데이터")).toBeNull();
@@ -43,11 +43,12 @@ describe("<Settings/>", () => {
   it("signed out: explains sync and calls login() from 연동하기 (#30: no feature-limit copy)", () => {
     render(<Settings {...base} />);
     expect(screen.getByText("로그인하면 방문 체크가 다른 기기와 동기화돼요")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "로그아웃" })).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "연동하기" }));
     expect(login).toHaveBeenCalledTimes(1);
   });
 
-  it("signed in: shows profile, sync status, account center, and calls onLogout from 연동 해제 (#34)", () => {
+  it("signed in: shows profile, sync status, and calls onLogout from the final 로그아웃 section (#52)", () => {
     const onLogout = vi.fn();
     render(<Settings {...base} user={USER} syncedAt={new Date(2026, 8, 2, 14, 5).getTime()} onLogout={onLogout} />);
     expect(screen.getByText("세오코")).toBeTruthy();
@@ -57,7 +58,11 @@ describe("<Settings/>", () => {
     expect(link.getAttribute("href")).toBe("https://auth.bini59.dev/client");
     expect(link.getAttribute("target")).toBe("_blank");
     expect(screen.queryByRole("button", { name: "연동하기" })).toBeNull();
-    fireEvent.click(screen.getByRole("button", { name: "연동 해제" }));
+    expect(screen.queryByRole("button", { name: "연동 해제" })).toBeNull();
+    const accountSection = screen.getByRole("heading", { name: "계정" }).parentElement!;
+    expect(accountSection.parentElement?.lastElementChild).toBe(accountSection);
+    expect(within(accountSection).getByRole("button", { name: "로그아웃" })).toBeTruthy();
+    fireEvent.click(within(accountSection).getByRole("button", { name: "로그아웃" }));
     expect(onLogout).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
## 변경 사항

- 로그인 상태에서만 설정 화면 최하단에 `계정` 섹션과 `로그아웃` 버튼을 표시합니다.
- 기존 `POST /api/auth/logout` 호출과 로컬 사용자/동기화 상태 초기화 로직을 재사용합니다.
- 연동 카드의 `연동 해제` 명칭과 동작을 제거하고 `로그아웃`으로 통일했습니다.
- 모바일 하단 네비게이션에 가리지 않도록 설정 페이지 하단 여백을 추가했습니다.
- 로그인/비로그인 렌더링, 최하단 배치, 로그아웃 API 호출 및 실패 시 로컬 로그아웃 회귀 테스트를 보강했습니다.

## 검증

- `npm run typecheck`
- `npm test` — 91 passed, 1 skipped
- `npm run build`
- `git diff --check`

Closes #52
