### PR TITLE
chore: track project Codex skills and ignore Codex-only CI

### DIFF
--- a/.codex/skills/gh-issue/SKILL.md
+++ b/.codex/skills/gh-issue/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: gh-issue
+description: "Pull a GitHub issue from bini59/317_gbc_seoko, read its body and comments, clarify the scope, then hand off to planning. Use when the user wants to start from an issue, says '이슈 가져와', or provides an issue number or URL."
+---
+
+# GitHub Issue Intake
+
+Pull a GitHub issue, clarify it, and hand the resolved scope to planning. Track work entirely in GitHub issues in `bini59/317_gbc_seoko`.
+
+## 1. Pick or create the issue
+
+- For a named issue, run `gh issue view <number> --repo bini59/317_gbc_seoko --comments`.
+- To browse, run `gh issue list --repo bini59/317_gbc_seoko --assignee @me --state open`; if empty, list all open issues.
+- Before creating an issue, show the proposed title and body and obtain user confirmation. Then run `gh issue create --repo bini59/317_gbc_seoko`.
+
+## 2. Read it fully
+
+Read the body and every comment. Summarize the requested outcome, constraints, acceptance criteria, and unresolved questions.
+
+## 3. Resolve the scope
+
+Run `$grill-with-docs` using the issue discussion as the starting point. Use `graphify-out/graph.json` and the codebase to answer repository questions before asking the user. Update `CONTEXT.md` or an ADR only when the domain-modeling rules call for it.
+
+Post material conclusions with `gh issue comment <number> --repo bini59/317_gbc_seoko --body "..."` only after confirming the comment with the user.
+
+## 4. Hand off
+
+Continue with `$dev-flow`, providing the issue link, resolved scope, acceptance criteria, and likely touched modules. Do not implement inside this intake skill.

--- a/.codex/skills/gh-issue/agents/openai.yaml
+++ b/.codex/skills/gh-issue/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "GitHub Issue Intake"
+  short_description: "Start scoped work from a project GitHub issue"
+  default_prompt: "Use $gh-issue to start work from a GitHub issue."

--- a/.codex/skills/release/SKILL.md
+++ b/.codex/skills/release/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: release
+description: "Release gbc-seoko to Cloudflare Workers from main, including build verification, SemVer versioning, tags, and hotfix handling. Use when the user wants to ship, deploy, bump the version, cut a release, or says '릴리즈 하자'."
+---
+
+# Release: gbc-seoko
+
+## Production (`main`)
+
+This repository deploys the Cloudflare Worker, D1 binding, and static client together. Treat `main` as the production source and use the Worker deployment command so the API and client are shipped as one unit.
+
+1. Ensure the worktree is clean and `main` is up to date with `origin/main`.
+2. Choose the next SemVer version from `package.json` and existing `v*` tags. Show the proposed version before changing it.
+3. Update the package version without creating an automatic npm tag: `npm version <version> --no-git-tag-version`.
+4. Run `npm ci` when dependencies need installation, then run `npm run build`.
+5. Review and commit the version change, then create the annotated tag `v<version>` only after user confirmation.
+6. Push `main` and the tag only after user confirmation.
+7. Deploy with `npm run deploy` only after explicit deployment confirmation. This builds the client and Worker, then runs `wrangler deploy` using `wrangler.jsonc`.
+8. Verify the deployed URL loads the SPA and that the Worker-backed API, search, filters, detail navigation, external links, and visit checks work.
+
+Do not use an `_redirects` SPA fallback; this single-route build uses relative assets and the repository documents that rewrite as invalid for its deployment path.
+
+## Hotfix
+
+1. Branch from the latest `main` as `hotfix/<short-description>`.
+2. Implement the smallest safe fix and run `npm run build` plus focused checks.
+3. Open a PR back to `main` and complete `$review-gate`.
+4. After merge, choose and confirm the next patch version, then follow the production version, tag, push, deployment, and verification steps above.
+
+There is no staging branch or separate back-merge path in this repository.

--- a/.codex/skills/release/agents/openai.yaml
+++ b/.codex/skills/release/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Release gbc-seoko"
+  short_description: "Build and deploy gbc-seoko to Cloudflare Pages"
+  default_prompt: "Use $release to prepare and deploy a gbc-seoko release."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,12 @@ name: CI
 
 on:
   pull_request:
+    paths-ignore:
+      - '.codex/**'
   push:
     branches: [main]
+    paths-ignore:
+      - '.codex/**'
 
 jobs:
   verify:

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ dist
 .DS_Store
 CLAUDE.local.md
 graphify-out/
-.codex/
 AGENTS.md
 CONTEXT.md
 tmp/


### PR DESCRIPTION
## Summary
- stop ignoring .codex/ so the project-local skills are tracked
- skip CI when all changed paths are under .codex/**
- align the tracked release skill with the Worker + D1 deployment command

## Verification
- npm run typecheck
- npm test (91 passed, 1 skipped)
- npm run build
- git diff --check
- graphify update .