### PR TITLE
feat: PWA 홈 화면 추가 안내 및 설치 UX (#53)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,8 @@ import { Detail } from "./components/Detail";
 import { EventList, Sidebar } from "./components/Sidebar";
 import { BottomNav, type Sheet } from "./components/BottomNav";
 import { Settings, useTheme } from "./components/Settings";
+import { InstallBanner } from "./components/InstallGuide";
+import { useInstallPrompt } from "./hooks/useInstallPrompt";
 import { eventSubtitle } from "./lib/event";
 
 /* ---------- 앱 ---------- */
@@ -28,6 +30,7 @@ export default function App() {
   const handleSyncError = useCallback(() => setAnnounce("방문 체크를 저장하지 못했어요"), []);
   const [checks, toggle] = useChecks(event?.slug ?? null, event?.status === "active", !!user, authLoading, handleSync, handleSyncError);
   const [theme, setTheme] = useTheme();
+  const install = useInstallPrompt();
   const [status, setStatus] = useState<Status>("all");
   const [selectedIps, setSelectedIps] = useState<string[]>([]);
   const [query, setQuery] = useState("");
@@ -217,12 +220,13 @@ export default function App() {
         {route.kind === "settings" ? (
           <div className="px-5 py-7 md:px-8 md:py-10">
             <h1 className="text-[26px] font-extrabold text-ink">설정</h1>
-            <div className="mt-7 max-w-[640px]"><Settings authEnabled={authEnabled} user={user} syncedAt={syncedAt} theme={theme} onTheme={setTheme} onLogout={handleLogout} /></div>
+            <div className="mt-7 max-w-[640px]"><Settings authEnabled={authEnabled} user={user} syncedAt={syncedAt} theme={theme} onTheme={setTheme} onLogout={handleLogout} install={install} /></div>
           </div>
         ) : route.kind === "events" ? (
           <div className="px-5 pt-7 pb-2 md:px-8 md:py-10">
             <h1 className="text-[26px] font-extrabold text-ink">행사 선택</h1>
             <p className="mt-2 text-sm text-muted">방문할 행사를 골라 관심 서클을 확인하세요.</p>
+            <InstallBanner install={install} onOpenSettings={openSettings} />
             {loadError ? <div role="alert" className="mt-8 text-sm text-danger">{loadError}</div> : null}
             {!loading && !loadError && events.length === 0 ? <div className="py-14 text-center text-sm text-faint">등록된 행사가 없어요</div> : null}
           </div>

--- a/src/components/InstallGuide.tsx
+++ b/src/components/InstallGuide.tsx
@@ -1,0 +1,77 @@
+import { useState } from "react";
+import type { InstallState } from "../hooks/useInstallPrompt";
+
+export const INSTALL_BANNER_DISMISSED_KEY = "gbc-seoko-install-banner-dismissed";
+
+function readBannerDismissed() {
+  try {
+    return localStorage.getItem(INSTALL_BANNER_DISMISSED_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+function saveBannerDismissed() {
+  try { localStorage.setItem(INSTALL_BANNER_DISMISSED_KEY, "true"); } catch { /* private mode */ }
+}
+
+const buttonCls = "inline-flex h-9 items-center justify-center rounded-full bg-ink px-4 text-[13px] font-bold text-bg";
+
+function ManualSteps() {
+  return (
+    <div className="grid gap-2.5 rounded-[12px] border border-line bg-card p-3.5 text-[13px] text-muted">
+      <div className="font-bold text-ink">브라우저에서 직접 추가하기</div>
+      <ol className="m-0 grid gap-2 pl-5">
+        <li>iPhone Safari에서 공유 버튼 선택</li>
+        <li>홈 화면에 추가 선택</li>
+        <li>추가 완료</li>
+        <li>Android Chrome 메뉴(⋮)에서 홈 화면에 추가 선택</li>
+        <li>다른 브라우저도 메뉴에서 홈 화면에 추가 또는 앱 설치 선택</li>
+      </ol>
+    </div>
+  );
+}
+
+export function InstallGuide({ install }: { install: InstallState }) {
+  return (
+    <section aria-labelledby="install-guide-title" className="grid gap-2.5">
+      <h3 id="install-guide-title" className="text-xs font-extrabold tracking-[0.04em] text-faint">홈 화면에 추가</h3>
+      {install.isInstalled ? (
+        <div role="status" className="rounded-[14px] border border-accent/30 bg-accent/10 px-3.5 py-3 text-[13px] font-semibold text-accent">홈 화면에 추가됨</div>
+      ) : (
+        <div className="grid gap-3 rounded-[14px] border border-line bg-card p-3.5">
+          <p className="m-0 text-[13px] text-muted">홈 화면에 추가하면 행사장에서 앱처럼 빠르게 열 수 있어요.</p>
+          {install.canPrompt ? <button type="button" onClick={() => void install.promptInstall()} className={buttonCls}>홈 화면에 추가</button> : null}
+          <ManualSteps />
+        </div>
+      )}
+    </section>
+  );
+}
+
+export function InstallBanner({ install, onOpenSettings }: { install: InstallState; onOpenSettings?: () => void }) {
+  const [dismissed, setDismissed] = useState(readBannerDismissed);
+
+  if (install.isInstalled || dismissed) return null;
+
+  const dismiss = () => {
+    saveBannerDismissed();
+    setDismissed(true);
+  };
+
+  return (
+    <section aria-labelledby="install-banner-title" className="mx-5 mt-6 rounded-[16px] border border-accent/30 bg-accent/10 p-4 md:mx-8">
+      <div className="flex items-start gap-3">
+        <div className="min-w-0 flex-1">
+          <h2 id="install-banner-title" className="m-0 text-[14px] font-extrabold text-ink">홈 화면에 추가하는 방법</h2>
+          <p className="mt-1.5 mb-0 text-[13px] leading-5 text-muted">이 체크리스트를 홈 화면에 추가하면 행사장에서 앱처럼 빠르게 열 수 있어요.</p>
+        </div>
+        <button type="button" aria-label="설치 안내 닫기" onClick={dismiss} className="shrink-0 text-faint">×</button>
+      </div>
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        {install.canPrompt ? <button type="button" onClick={() => void install.promptInstall()} className={buttonCls}>홈 화면에 추가</button> : null}
+        <a href="#/settings" onClick={(event) => { if (onOpenSettings) { event.preventDefault(); onOpenSettings(); } }} className="text-[13px] font-bold text-accent no-underline">설치 방법 자세히 보기</a>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1,5 +1,7 @@
 import { useState } from "react";
 import { AUTH_ORIGIN, login, type AuthUser } from "../api";
+import { InstallGuide } from "./InstallGuide";
+import type { InstallState } from "../hooks/useInstallPrompt";
 
 const ACCOUNT_CENTER_URL = `${AUTH_ORIGIN}/client`;
 const ISSUES_URL = "https://github.com/bini59/317_gbc_seoko/issues";
@@ -70,6 +72,7 @@ export function Settings({
   theme,
   onTheme,
   onLogout,
+  install,
 }: {
   authEnabled: boolean;
   user: AuthUser | null;
@@ -77,6 +80,7 @@ export function Settings({
   theme: Theme;
   onTheme: (next: Theme) => void;
   onLogout: () => void;
+  install: InstallState;
 }) {
 
   const displayName = user?.name ?? user?.email ?? "사용자";
@@ -114,6 +118,8 @@ export function Settings({
           )}
         </section>
       ) : null}
+
+      <InstallGuide install={install} />
 
       <section className="grid gap-2.5">
         <h3 className={headingCls}>화면</h3>

--- a/src/hooks/useInstallPrompt.ts
+++ b/src/hooks/useInstallPrompt.ts
@@ -1,0 +1,62 @@
+import { useCallback, useEffect, useState } from "react";
+
+export type InstallOutcome = "accepted" | "dismissed";
+
+export type InstallState = {
+  isInstalled: boolean;
+  canPrompt: boolean;
+  promptInstall: () => Promise<InstallOutcome | null>;
+};
+
+type BeforeInstallPromptEvent = Event & {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: InstallOutcome }>;
+};
+
+function isStandalone() {
+  if (typeof window === "undefined") return false;
+  const displayMode = typeof window.matchMedia === "function" && window.matchMedia("(display-mode: standalone)").matches;
+  const iosStandalone = typeof navigator !== "undefined" && (navigator as Navigator & { standalone?: boolean }).standalone === true;
+  return Boolean(displayMode || iosStandalone);
+}
+
+/** Captures the deferred browser prompt while keeping installation state independent from UI dismissal. */
+export function useInstallPrompt(): InstallState {
+  const [isInstalled, setIsInstalled] = useState(isStandalone);
+  const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
+
+  useEffect(() => {
+    const onBeforeInstallPrompt = (event: Event) => {
+      const promptEvent = event as Partial<BeforeInstallPromptEvent>;
+      if (typeof promptEvent.prompt !== "function" || !promptEvent.userChoice) return;
+      event.preventDefault();
+      setDeferredPrompt(promptEvent as BeforeInstallPromptEvent);
+    };
+    const onAppInstalled = () => {
+      setDeferredPrompt(null);
+      setIsInstalled(true);
+    };
+
+    window.addEventListener("beforeinstallprompt", onBeforeInstallPrompt);
+    window.addEventListener("appinstalled", onAppInstalled);
+    return () => {
+      window.removeEventListener("beforeinstallprompt", onBeforeInstallPrompt);
+      window.removeEventListener("appinstalled", onAppInstalled);
+    };
+  }, []);
+
+  const promptInstall = useCallback(async () => {
+    if (!deferredPrompt) return null;
+    setDeferredPrompt(null);
+    try {
+      await deferredPrompt.prompt();
+      const { outcome } = await deferredPrompt.userChoice;
+      if (outcome === "accepted") setIsInstalled(true);
+      return outcome;
+    } catch {
+      return null;
+    }
+  }, [deferredPrompt]);
+
+  return { isInstalled, canPrompt: deferredPrompt !== null, promptInstall };
+}

--- a/test/client/App.test.tsx
+++ b/test/client/App.test.tsx
@@ -76,12 +76,22 @@ describe("<App/> confirmed + unlisted", () => {
   it("shows registered events at the root and opens the selected checklist", async () => {
     render(<App />);
     expect(await screen.findByRole("heading", { name: "행사 선택" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "홈 화면에 추가하는 방법" })).toBeTruthy();
     expect(screen.getByRole("heading", { name: "진행 중" })).toBeTruthy();
     expect(screen.getByRole("heading", { name: "예정" })).toBeTruthy();
     expect(screen.getByText("코믹월드")).toBeTruthy();
     fireEvent.click(screen.getByRole("link", { name: /일러스타 페스/ }));
     await waitFor(() => expect(window.location.hash).toBe("#/events/illustar"));
     expect(await screen.findByText("부스서클")).toBeTruthy();
+  });
+
+  it("opens the detailed installation guide from the event landing card", async () => {
+    render(<App />);
+    await screen.findByRole("heading", { name: "행사 선택" });
+    fireEvent.click(screen.getByRole("link", { name: "설치 방법 자세히 보기" }));
+
+    expect(window.location.hash).toBe("#/settings");
+    expect(await screen.findByRole("heading", { name: "홈 화면에 추가" })).toBeTruthy();
   });
 
   it("marks the current 행사 in the sidebar", async () => {

--- a/test/client/Install.test.tsx
+++ b/test/client/Install.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { InstallBanner, InstallGuide } from "../../src/components/InstallGuide";
+import { useInstallPrompt, type InstallState } from "../../src/hooks/useInstallPrompt";
+
+function Harness() {
+  const install = useInstallPrompt();
+  return (
+    <>
+      <InstallBanner install={install} />
+      <div data-testid="installed">{String(install.isInstalled)}</div>
+    </>
+  );
+}
+
+function deferredPrompt(outcome: "accepted" | "dismissed") {
+  const event = new Event("beforeinstallprompt", { cancelable: true }) as Event & {
+    prompt: ReturnType<typeof vi.fn>;
+    userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
+  };
+  event.prompt = vi.fn().mockResolvedValue(undefined);
+  event.userChoice = Promise.resolve({ outcome });
+  return event;
+}
+
+const noPrompt: InstallState = {
+  isInstalled: false,
+  canPrompt: false,
+  promptInstall: vi.fn(),
+};
+
+describe("PWA install guidance", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.stubGlobal("matchMedia", vi.fn(() => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() })));
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("defers the supported browser prompt until the user clicks install", async () => {
+    render(<Harness />);
+    const event = deferredPrompt("accepted");
+    window.dispatchEvent(event);
+
+    const button = await screen.findByRole("button", { name: "홈 화면에 추가" });
+    expect(event.prompt).not.toHaveBeenCalled();
+    fireEvent.click(button);
+
+    await waitFor(() => expect(event.prompt).toHaveBeenCalledTimes(1));
+    expect(screen.getByTestId("installed").textContent).toBe("true");
+    expect(screen.queryByRole("button", { name: "홈 화면에 추가" })).toBeNull();
+  });
+
+  it("keeps the guidance visible when the install prompt is dismissed", async () => {
+    render(<Harness />);
+    const event = deferredPrompt("dismissed");
+    window.dispatchEvent(event);
+    fireEvent.click(await screen.findByRole("button", { name: "홈 화면에 추가" }));
+
+    await waitFor(() => expect(event.prompt).toHaveBeenCalledTimes(1));
+    expect(screen.getByText("홈 화면에 추가하는 방법")).toBeTruthy();
+    expect(screen.getByTestId("installed").textContent).toBe("false");
+  });
+
+  it("shows manual platform steps without requiring browser install APIs", () => {
+    render(<InstallGuide install={noPrompt} />);
+
+    expect(screen.queryByRole("button", { name: "홈 화면에 추가" })).toBeNull();
+    expect(screen.getByText("iPhone Safari에서 공유 버튼 선택")).toBeTruthy();
+    expect(screen.getByText("추가 완료")).toBeTruthy();
+    expect(screen.getByText("Android Chrome 메뉴(⋮)에서 홈 화면에 추가 선택")).toBeTruthy();
+  });
+
+  it("hides install calls when the app is already running standalone", () => {
+    render(<InstallGuide install={{ ...noPrompt, isInstalled: true }} />);
+
+    expect(screen.getByText("홈 화면에 추가됨")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "홈 화면에 추가" })).toBeNull();
+  });
+
+  it("detects standalone mode from the display-mode media query", () => {
+    vi.stubGlobal("matchMedia", vi.fn(() => ({ matches: true, addEventListener: vi.fn(), removeEventListener: vi.fn() })));
+    render(<Harness />);
+
+    expect(screen.getByTestId("installed").textContent).toBe("true");
+    expect(screen.queryByRole("heading", { name: "홈 화면에 추가하는 방법" })).toBeNull();
+  });
+
+  it("marks the app installed when the browser emits appinstalled", async () => {
+    render(<Harness />);
+    window.dispatchEvent(new Event("appinstalled"));
+
+    await waitFor(() => expect(screen.getByTestId("installed").textContent).toBe("true"));
+    expect(screen.queryByRole("heading", { name: "홈 화면에 추가하는 방법" })).toBeNull();
+  });
+
+  it("stores the event-list card dismissal independently", () => {
+    const { unmount } = render(<InstallBanner install={noPrompt} />);
+    fireEvent.click(screen.getByRole("button", { name: "설치 안내 닫기" }));
+    expect(localStorage.getItem("gbc-seoko-install-banner-dismissed")).toBe("true");
+
+    unmount();
+    render(<InstallBanner install={noPrompt} />);
+    expect(screen.queryByText(/앱처럼 빠르게 열 수 있어요/)).toBeNull();
+    expect(screen.queryByText("Safari의 공유 버튼 선택")).toBeNull();
+  });
+});

--- a/test/client/Settings.test.tsx
+++ b/test/client/Settings.test.tsx
@@ -2,6 +2,7 @@
 import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 import { Settings, useTheme } from "../../src/components/Settings";
+import type { InstallState } from "../../src/hooks/useInstallPrompt";
 
 vi.mock("../../src/api", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../src/api")>()),
@@ -11,7 +12,8 @@ import { login } from "../../src/api";
 
 const USER = { userId: "u1", email: "seoko@example.com", name: "세오코", avatarUrl: null };
 const noop = () => {};
-const base = { authEnabled: true, user: null, syncedAt: null, theme: "system" as const, onTheme: noop, onLogout: noop };
+const noInstall: InstallState = { isInstalled: false, canPrompt: false, promptInstall: vi.fn() };
+const base = { authEnabled: true, user: null, syncedAt: null, theme: "system" as const, onTheme: noop, onLogout: noop, install: noInstall };
 
 /** 실제 배선과 동일 — 테마 상태는 부모(App)의 useTheme가 들고 내려준다 */
 function Themed(props: Partial<Parameters<typeof Settings>[0]>) {
@@ -86,6 +88,19 @@ describe("<Settings/>", () => {
     localStorage.setItem("theme", "light");
     render(<Themed />);
     expect(screen.getByRole("button", { name: "라이트" }).getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("shows the manual home-screen installation guide when prompting is unavailable", () => {
+    render(<Settings {...base} />);
+    expect(screen.getByRole("heading", { name: "홈 화면에 추가" })).toBeTruthy();
+    expect(screen.getByText("iPhone Safari에서 공유 버튼 선택")).toBeTruthy();
+    expect(screen.getByText("Android Chrome 메뉴(⋮)에서 홈 화면에 추가 선택")).toBeTruthy();
+  });
+
+  it("shows the installed state without a call to action", () => {
+    render(<Settings {...base} install={{ ...noInstall, isInstalled: true }} />);
+    expect(screen.getByText("홈 화면에 추가됨")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "홈 화면에 추가" })).toBeNull();
   });
 
 });


### PR DESCRIPTION
## Summary
- 행사 목록에 홈 화면 추가 안내 카드를 추가하고 닫힘 상태를 브라우저별로 저장
- `beforeinstallprompt`, `appinstalled`, standalone 상태를 관리하는 설치 훅 추가
- 설정 화면에 지원 브라우저 CTA와 iPhone Safari/Android Chrome 수동 설치 가이드 추가
- 설치 수락/취소, standalone, appinstalled, 카드 닫힘 및 라우팅 테스트 추가

Closes #53

## Verification
- `npm run typecheck`
- `npm test` (101 passed, 1 skipped)
- `npm run build`
- PWA manifest/service worker/icon artifacts verified
