### PR TITLE
feat: 행사 데이터 로컬 캐시 및 방문 체크 저장 기반

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 - CSR SPA (Vite + React), 체크 상태는 브라우저 `localStorage`에 저장
 - 각 서클의 X(트위터), 통판, 행사 관련 링크를 새 탭으로 열어 확인
+- 행사·서클 응답은 서버 MD5 메타데이터와 버전 캐시를 사용하며, 네트워크가 끊기면 유효한 로컬 캐시로 대체
 
 ## 로컬 실행
 ```bash
@@ -47,6 +48,13 @@ npm run preview # 빌드 결과 미리보기
 - 모든 쓰기 요청은 런타임 스키마 검증(`worker/validate.ts`)을 통과해야 한다(slug/URL/enum/배열/숫자 ID).
 - 서클 upsert는 다중 테이블을 D1 `batch()`(단일 트랜잭션)로 원자 처리 — 전부 성공 또는 전부 롤백.
 - 쓰기 허용 origin은 `ALLOWED_ORIGINS`(쉼표 구분) 환경변수로 제한한다. 미설정 시 `*`.
+
+읽기 데이터의 변경 감지는 `GET /api/events?metadata=1` 및
+`GET /api/circles?event=<slug>&status=all&metadata=1`의 `{ meta: { schemaVersion, hash } }`로 확인한다.
+전체 응답에도 같은 `meta`가 포함된다. 브라우저는 행사 목록을
+`gbc-seoko-cache:v1:events`, 행사별 서클을
+`gbc-seoko-cache:v1:circles:<eventSlug>`에 `schemaVersion/hash/data/cachedAt` 형태로 저장한다.
+로그인 정보와 세션 쿠키는 이 저장 구조에 포함하지 않는다.
 
 ## Cloudflare 배포
 ### 방법 A — Workers (권장)

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,8 @@
 import type { Circle, TweetInfo } from "./types";
 import type { Checks } from "./lib/checks";
+import { cacheKeys, loadCache, saveCache, type CacheStorage } from "./lib/cache";
+
+export type ApiMeta = { schemaVersion: number; hash: string };
 
 export type ApiCircle = {
   id: number;
@@ -32,6 +35,73 @@ export type ApiEvent = {
   status: string;
 };
 
+type DatasetLoader<T> = {
+  cacheKey: string;
+  metadataUrl: string;
+  dataUrl: string;
+  errorMessage: string;
+  isData: (value: unknown) => value is T;
+  parseData: (body: unknown) => T | null;
+};
+
+function browserStorage(): CacheStorage | null {
+  return typeof localStorage === "undefined" ? null : localStorage;
+}
+
+function parseMeta(body: unknown): ApiMeta | null {
+  if (!body || typeof body !== "object") return null;
+  const meta = (body as Record<string, unknown>).meta;
+  if (!meta || typeof meta !== "object") return null;
+  const value = meta as Record<string, unknown>;
+  if (value.schemaVersion !== 1 || typeof value.hash !== "string" || !/^[a-f0-9]{32}$/i.test(value.hash)) return null;
+  return { schemaVersion: value.schemaVersion, hash: value.hash.toLowerCase() };
+}
+
+function isAbort(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "AbortError";
+}
+
+async function requestJson(url: string, signal?: AbortSignal): Promise<{ response: Response; body: unknown }> {
+  const response = signal ? await fetch(url, { signal }) : await fetch(url);
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    body = null;
+  }
+  return { response, body };
+}
+
+async function loadDataset<T>({ cacheKey, metadataUrl, dataUrl, errorMessage, isData, parseData }: DatasetLoader<T>, signal?: AbortSignal): Promise<T> {
+  const storage = browserStorage();
+  const cached = storage ? loadCache(storage, cacheKey, isData) : null;
+  let remoteMeta: ApiMeta | null = null;
+
+  try {
+    const metadata = await requestJson(metadataUrl, signal);
+    if (metadata.response.ok) remoteMeta = parseMeta(metadata.body);
+    if (remoteMeta && cached && cached.hash === remoteMeta.hash) return cached.data;
+    if (!remoteMeta && cached) return cached.data;
+  } catch (error) {
+    if (isAbort(error)) throw error;
+    if (cached) return cached.data;
+  }
+
+  try {
+    const full = await requestJson(dataUrl, signal);
+    if (!full.response.ok) throw new Error(errorMessage);
+    const data = parseData(full.body);
+    if (data === null) throw new Error("API response was invalid");
+    const meta = parseMeta(full.body) ?? remoteMeta;
+    if (storage && meta) saveCache(storage, cacheKey, meta.hash, data);
+    return data;
+  } catch (error) {
+    if (isAbort(error)) throw error;
+    if (cached) return cached.data;
+    throw error;
+  }
+}
+
 function toCircle(c: ApiCircle): Circle {
   return {
     id: c.slug,
@@ -55,10 +125,27 @@ export function pickActiveEvent(events: ApiEvent[]): ApiEvent | null {
 }
 
 export async function fetchEvents(signal?: AbortSignal): Promise<ApiEvent[]> {
-  const res = signal ? await fetch("/api/events", { signal }) : await fetch("/api/events");
-  if (!res.ok) throw new Error("이벤트 정보를 불러오지 못했어요");
-  const data = await res.json();
-  return data.events || [];
+  return loadDataset({
+    cacheKey: cacheKeys.events,
+    metadataUrl: "/api/events?metadata=1",
+    dataUrl: "/api/events",
+    errorMessage: "이벤트 정보를 불러오지 못했어요",
+    isData: (value): value is ApiEvent[] => Array.isArray(value) && value.every((event) => (
+      event !== null && typeof event === "object"
+      && typeof (event as { slug?: unknown }).slug === "string"
+      && typeof (event as { title?: unknown }).title === "string"
+    )),
+    parseData: (body) => {
+      if (!body || typeof body !== "object") return null;
+      const events = (body as { events?: unknown }).events;
+      if (!Array.isArray(events) || !events.every((event) => (
+        event !== null && typeof event === "object"
+        && typeof (event as { slug?: unknown }).slug === "string"
+        && typeof (event as { title?: unknown }).title === "string"
+      ))) return null;
+      return events as ApiEvent[];
+    },
+  }, signal);
 }
 
 export type AuthUser = {
@@ -107,15 +194,37 @@ export async function fetchCircles(
   eventSlug: string,
   signal?: AbortSignal,
 ): Promise<{ circles: Circle[]; witchformExtra: Circle[] }> {
-  const res = await fetch(
-    `/api/circles?event=${encodeURIComponent(eventSlug)}&status=all`,
-    { signal },
-  );
-  if (!res.ok) throw new Error("서클 목록을 불러오지 못했어요");
-  const data = await res.json();
-  const all: ApiCircle[] = data.circles || [];
-  return {
-    circles: all.filter((c) => c.status === "confirmed").map(toCircle),
-    witchformExtra: all.filter((c) => c.status === "unlisted").map(toCircle),
-  };
+  const query = `event=${encodeURIComponent(eventSlug)}&status=all`;
+  return loadDataset({
+    cacheKey: cacheKeys.circles(eventSlug),
+    metadataUrl: `/api/circles?${query}&metadata=1`,
+    dataUrl: `/api/circles?${query}`,
+    errorMessage: "서클 목록을 불러오지 못했어요",
+    isData: (value): value is { circles: Circle[]; witchformExtra: Circle[] } => {
+      if (!value || typeof value !== "object") return false;
+      const data = value as { circles?: unknown; witchformExtra?: unknown };
+      return [data.circles, data.witchformExtra].every((list) => Array.isArray(list) && list.every((circle) => (
+        circle !== null && typeof circle === "object"
+        && typeof (circle as { id?: unknown }).id === "string"
+        && typeof (circle as { name?: unknown }).name === "string"
+        && Array.isArray((circle as { links?: unknown }).links)
+      )));
+    },
+    parseData: (body) => {
+      if (!body || typeof body !== "object") return null;
+      const circles = (body as { circles?: unknown }).circles;
+      if (!Array.isArray(circles)) return null;
+      const all = circles as ApiCircle[];
+      if (!all.every((circle) => (
+        circle !== null && typeof circle === "object"
+        && typeof circle.slug === "string"
+        && typeof circle.name === "string"
+        && Array.isArray(circle.links)
+      ))) return null;
+      return {
+        circles: all.filter((circle) => circle.status === "confirmed").map(toCircle),
+        witchformExtra: all.filter((circle) => circle.status === "unlisted").map(toCircle),
+      };
+    },
+  }, signal);
 }

--- a/src/hooks/useChecks.ts
+++ b/src/hooks/useChecks.ts
@@ -3,8 +3,8 @@ import { type Checks, loadChecks, saveChecks } from "../lib/checks";
 import { fetchChecks, saveChecks as saveRemoteChecks } from "../api";
 
 /**
- * 행사별 방문 체크 상태. 비로그인은 localStorage를 사용하고, 로그인 사용자는
- * 321_auth 세션으로 확인한 계정별 원격 저장소를 사용한다.
+ * 행사별 방문 체크 상태. 모든 사용자는 localStorage를 기준으로 사용하고,
+ * 로그인 사용자는 321_auth 세션으로 확인한 계정별 원격 저장소에도 저장한다.
  * `onSync(mergedCount)`는 원격 저장이 성공할 때마다 불린다 — 첫 병합은 로컬에서 올라간 체크 개수, 이후 저장은 0.
  * 저장 실패는 `onSyncError`로 알린다(상태는 되돌리지 않는다).
  */
@@ -33,6 +33,8 @@ export function useChecks(
     void fetchChecks(eventSlug).then(({ checks: remote }) => {
       const merged = { ...local, ...remote };
       setChecks(merged);
+      // 로그인 상태에서도 다음 로드와 로그아웃 이후를 위해 로컬 기준을 최신화한다.
+      saveChecks(localStorage, eventSlug, merged);
       // 원격과 다른 항목이 있을 때만 올린다 — 단순 로드는 저장도 안내도 없다
       if (!Object.keys(merged).some((id) => merged[id] !== remote[id])) return;
       const fromLocal = Object.keys(local).filter((id) => local[id] && !remote[id]).length;
@@ -42,8 +44,8 @@ export function useChecks(
 
   const persist = (next: Checks) => {
     if (!eventSlug) return;
+    saveChecks(localStorage, eventSlug, next);
     if (authenticated) void saveRemoteChecks(eventSlug, next).then(() => cb.current.onSync?.(0), () => cb.current.onSyncError?.());
-    else saveChecks(localStorage, eventSlug, next);
   };
 
   const toggle = (id: string) =>

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -1,0 +1,60 @@
+export const CACHE_SCHEMA_VERSION = 1;
+
+export interface CacheStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+export type CacheEntry<T> = {
+  schemaVersion: number;
+  hash: string;
+  data: T;
+  cachedAt: number;
+};
+
+export const cacheKeys = {
+  events: "gbc-seoko-cache:v1:events",
+  circles: (eventSlug: string) => `gbc-seoko-cache:v1:circles:${eventSlug}`,
+};
+
+function isHash(value: unknown): value is string {
+  return typeof value === "string" && /^[a-f0-9]{32}$/i.test(value);
+}
+
+export function loadCache<T>(
+  storage: CacheStorage,
+  key: string,
+  isData: (value: unknown) => value is T,
+): CacheEntry<T> | null {
+  try {
+    const raw = storage.getItem(key);
+    if (raw === null) return null;
+    const value: unknown = JSON.parse(raw);
+    if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+    const entry = value as Record<string, unknown>;
+    if (
+      entry.schemaVersion !== CACHE_SCHEMA_VERSION
+      || !isHash(entry.hash)
+      || typeof entry.cachedAt !== "number"
+      || !Number.isFinite(entry.cachedAt)
+      || !isData(entry.data)
+    ) return null;
+    return entry as CacheEntry<T>;
+  } catch {
+    return null;
+  }
+}
+
+export function saveCache<T>(storage: CacheStorage, key: string, hash: string, data: T): void {
+  if (!isHash(hash)) return;
+  try {
+    storage.setItem(key, JSON.stringify({
+      schemaVersion: CACHE_SCHEMA_VERSION,
+      hash: hash.toLowerCase(),
+      data,
+      cachedAt: Date.now(),
+    } satisfies CacheEntry<T>));
+  } catch {
+    // localStorage may be unavailable in private mode or over quota.
+  }
+}

--- a/src/lib/checks.ts
+++ b/src/lib/checks.ts
@@ -16,7 +16,11 @@ function parse(raw: string | null): Checks {
   if (!raw) return {};
   try {
     const v = JSON.parse(raw);
-    return v && typeof v === "object" ? (v as Checks) : {};
+    if (!v || typeof v !== "object" || Array.isArray(v)) return {};
+    const entries = Object.entries(v);
+    return entries.every(([key, value]) => key.length <= 200 && typeof value === "boolean")
+      ? Object.fromEntries(entries) as Checks
+      : {};
   } catch {
     return {};
   }
@@ -40,7 +44,11 @@ export function loadChecks(kv: KV, eventSlug: string, migrateLegacy = false): Ch
 
   if (migrateLegacy && kv.getItem(MIGRATED_FLAG) === null) {
     const legacy = kv.getItem(LEGACY_KEY);
-    kv.setItem(MIGRATED_FLAG, "1");
+    try {
+      kv.setItem(MIGRATED_FLAG, "1");
+    } catch {
+      // private mode / quota; the legacy data can still be read for this load
+    }
     if (legacy !== null) {
       const migrated = parse(legacy);
       saveChecks(kv, eventSlug, migrated);

--- a/test/client/App.test.tsx
+++ b/test/client/App.test.tsx
@@ -228,6 +228,23 @@ describe("<App/> confirmed + unlisted", () => {
     expect(Object.values(stored).some(Boolean)).toBe(true);
   });
 
+  it("persists a signed-in visit check locally before remote sync", async () => {
+    window.location.hash = "#/events/ev";
+    mockApi(CIRCLES, true, { userId: "u1", email: null, name: "세오코", avatarUrl: null });
+    render(<App />);
+    await screen.findByText("부스서클");
+    fireEvent.click(screen.getByLabelText("방문 체크"));
+
+    await waitFor(() => {
+      const stored = JSON.parse(localStorage.getItem("gbc-seoko-checks:ev") || "{}");
+      expect(stored.tsuhan1).toBe(true);
+    });
+    expect(vi.mocked(fetch)).toHaveBeenCalledWith(
+      expect.stringContaining("/api/checks?event=ev"),
+      expect.objectContaining({ method: "PUT" }),
+    );
+  });
+
   it("builds top filters only from the selected 행사의 IPs and hides a missing map link", async () => {
     window.location.hash = "#/events/ev";
     render(<App />);

--- a/test/client/a11y-routing.test.tsx
+++ b/test/client/a11y-routing.test.tsx
@@ -98,10 +98,13 @@ describe("<App/> accessibility + routing", () => {
 
   it("shows a retry button that re-fetches without a page reload", async () => {
     window.location.hash = "#/events/ev";
+    let failures = 0;
     const fetchMock = vi
       .fn()
-      .mockRejectedValueOnce(new Error("네트워크 오류"))
       .mockImplementation(async (url: string) => {
+        if ((url.includes("/api/events") || url.includes("/api/circles")) && failures++ < 2) {
+          throw new Error("네트워크 오류");
+        }
         if (url.includes("/api/events")) return json({ events: [EVENT] });
         if (url.includes("/api/circles")) return json({ circles: CIRCLES });
         throw new Error("unexpected " + url);

--- a/test/client/api.test.ts
+++ b/test/client/api.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, describe, it, expect, vi } from "vitest";
-import { fetchEvents, pickActiveEvent, type ApiEvent } from "../../src/api";
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
+import { fetchCircles, fetchEvents, pickActiveEvent, type ApiEvent } from "../../src/api";
 
 const ev = (slug: string, status: string): ApiEvent =>
   ({ id: 1, slug, title: slug, alias: null, fare_id: null, date_label: null, start_date: null, end_date: null, venue: null, map_url: null, status }) as ApiEvent;
@@ -17,13 +17,58 @@ describe("pickActiveEvent", () => {
 });
 
 describe("fetchEvents", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", {
+      values: new Map<string, string>(),
+      getItem(key: string) { return this.values.has(key) ? this.values.get(key) : null; },
+      setItem(key: string, value: string) { this.values.set(key, value); },
+    });
+  });
   afterEach(() => vi.unstubAllGlobals());
 
   it("returns every registered 행사 so callers can choose one", async () => {
     const events = [ev("illustar-fes-9", "upcoming"), ev("comic-world-2026-07", "past")];
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => ({ events }) }));
+    vi.stubGlobal("fetch", vi.fn(async (url: string) => ({
+      ok: true,
+      json: async () => url.includes("metadata")
+        ? { meta: { schemaVersion: 1, hash: "a".repeat(32) } }
+        : { events, meta: { schemaVersion: 1, hash: "a".repeat(32) } },
+    })));
 
     await expect(fetchEvents()).resolves.toEqual(events);
-    expect(fetch).toHaveBeenCalledWith("/api/events");
+    expect(fetch).toHaveBeenNthCalledWith(1, "/api/events?metadata=1");
+    expect(fetch).toHaveBeenNthCalledWith(2, "/api/events");
+  });
+
+  it("uses a matching event cache without downloading the dataset", async () => {
+    localStorage.setItem("gbc-seoko-cache:v1:events", JSON.stringify({
+      schemaVersion: 1,
+      hash: "b".repeat(32),
+      cachedAt: Date.now(),
+      data: [ev("cached", "active")],
+    }));
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ meta: { schemaVersion: 1, hash: "b".repeat(32) } }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchEvents()).resolves.toEqual([ev("cached", "active")]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to a valid circle cache when metadata and data requests fail", async () => {
+    localStorage.setItem("gbc-seoko-cache:v1:circles:ev", JSON.stringify({
+      schemaVersion: 1,
+      hash: "c".repeat(32),
+      cachedAt: Date.now(),
+      data: { circles: [{ id: "cached", name: "캐시", links: [] }], witchformExtra: [] },
+    }));
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+
+    await expect(fetchCircles("ev")).resolves.toEqual({
+      circles: [{ id: "cached", name: "캐시", links: [] }],
+      witchformExtra: [],
+    });
   });
 });

--- a/test/client/cache.test.ts
+++ b/test/client/cache.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { cacheKeys, loadCache, saveCache, type CacheStorage } from "../../src/lib/cache";
+
+function fakeStorage(seed: Record<string, string> = {}): CacheStorage & { store: Map<string, string> } {
+  const store = new Map(Object.entries(seed));
+  return {
+    store,
+    getItem: (key) => (store.has(key) ? store.get(key)! : null),
+    setItem: (key, value) => void store.set(key, value),
+  };
+}
+
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every((item) => typeof item === "string");
+
+describe("versioned API cache", () => {
+  it("stores a versioned envelope under the dataset key", () => {
+    const storage = fakeStorage();
+    saveCache(storage, cacheKeys.events, "a".repeat(32), ["event"]);
+
+    expect(JSON.parse(storage.store.get(cacheKeys.events)!)).toMatchObject({
+      schemaVersion: 1,
+      hash: "a".repeat(32),
+      data: ["event"],
+    });
+    expect(loadCache(storage, cacheKeys.events, isStringArray)?.data).toEqual(["event"]);
+  });
+
+  it("rejects corrupted, mismatched, or malformed cache envelopes", () => {
+    const storage = fakeStorage({
+      [cacheKeys.events]: JSON.stringify({ schemaVersion: 99, hash: "a".repeat(32), data: [] }),
+    });
+    expect(loadCache(storage, cacheKeys.events, isStringArray)).toBeNull();
+
+    storage.store.set(cacheKeys.events, "{broken");
+    expect(loadCache(storage, cacheKeys.events, isStringArray)).toBeNull();
+
+    storage.store.set(cacheKeys.events, JSON.stringify({
+      schemaVersion: 1,
+      hash: "a".repeat(32),
+      cachedAt: Date.now(),
+      data: { not: "an array" },
+    }));
+    expect(loadCache(storage, cacheKeys.events, isStringArray)).toBeNull();
+  });
+
+  it("keeps event datasets in separate keys", () => {
+    expect(cacheKeys.circles("event-a")).not.toBe(cacheKeys.circles("event-b"));
+    expect(cacheKeys.circles("event-a")).toBe("gbc-seoko-cache:v1:circles:event-a");
+  });
+});

--- a/test/client/checks.test.ts
+++ b/test/client/checks.test.ts
@@ -42,4 +42,9 @@ describe("per-event checks", () => {
     const kv = fakeKV({ [checksKey("ev")]: "{broken" });
     expect(loadChecks(kv, "ev")).toEqual({});
   });
+
+  it("ignores check entries that are not booleans", () => {
+    const kv = fakeKV({ [checksKey("ev")]: JSON.stringify({ good: true, bad: "yes" }) });
+    expect(loadChecks(kv, "ev")).toEqual({});
+  });
 });

--- a/test/worker/api.test.ts
+++ b/test/worker/api.test.ts
@@ -156,6 +156,37 @@ describe("worker API", () => {
     expect(list.json.events.map((e: any) => e.slug)).toContain("cw-2026-07");
   });
 
+  it("provides stable MD5 metadata without returning event data", async () => {
+    await call(env, "POST", "/api/events", { slug: "ev", title: "T", status: "active" });
+    const first = await call(env, "GET", "/api/events?metadata=1");
+    expect(first.status).toBe(200);
+    expect(first.json).toMatchObject({ meta: { schemaVersion: 1, hash: expect.stringMatching(/^[a-f0-9]{32}$/) } });
+    expect(first.json).not.toHaveProperty("events");
+
+    const second = await call(env, "GET", "/api/events?metadata=1");
+    expect(second.json.meta.hash).toBe(first.json.meta.hash);
+    const full = await call(env, "GET", "/api/events");
+    expect(full.json.meta).toEqual(first.json.meta);
+  });
+
+  it("changes circle metadata when event data changes and keeps it event-scoped", async () => {
+    await call(env, "POST", "/api/events", { slug: "a", title: "A", status: "active" });
+    await call(env, "POST", "/api/events", { slug: "b", title: "B", status: "upcoming" });
+    await call(env, "POST", "/api/circles", { slug: "same", name: "A 서클", event_slug: "a" });
+    await call(env, "POST", "/api/circles", { slug: "same", name: "B 서클", event_slug: "b" });
+
+    const a = await call(env, "GET", "/api/circles?event=a&status=all&metadata=1");
+    const b = await call(env, "GET", "/api/circles?event=b&status=all&metadata=1");
+    expect(a.json).toMatchObject({ meta: { schemaVersion: 1, hash: expect.stringMatching(/^[a-f0-9]{32}$/) } });
+    expect(b.json.meta.hash).not.toBe(a.json.meta.hash);
+
+    await call(env, "POST", "/api/circles", { slug: "new", name: "새 서클", event_slug: "a" });
+    const changedA = await call(env, "GET", "/api/circles?event=a&status=all&metadata=1");
+    const unchangedB = await call(env, "GET", "/api/circles?event=b&status=all&metadata=1");
+    expect(changedA.json.meta.hash).not.toBe(a.json.meta.hash);
+    expect(unchangedB.json.meta.hash).toBe(b.json.meta.hash);
+  });
+
   it("determines event status with inclusive event dates", () => {
     expect(determineEventStatus({ start_date: "2026-09-02", end_date: "2026-09-03", status: "past" }, "2026-09-01")).toBe("upcoming");
     expect(determineEventStatus({ start_date: "2026-09-02", end_date: "2026-09-03", status: "past" }, "2026-09-02")).toBe("active");

--- a/test/worker/md5.test.ts
+++ b/test/worker/md5.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { md5Hex } from "../../worker/md5";
+
+describe("md5Hex", () => {
+  it("returns the standard MD5 digest for UTF-8 text", async () => {
+    await expect(md5Hex("")).resolves.toBe("d41d8cd98f00b204e9800998ecf8427e");
+    await expect(md5Hex("The quick brown fox jumps over the lazy dog"))
+      .resolves.toBe("9e107d9d372bb6826bd81d3542a419d6");
+  });
+});

--- a/worker/app.ts
+++ b/worker/app.ts
@@ -14,6 +14,7 @@ import {
   optBool,
   dateOnly,
 } from "./validate";
+import { md5Hex } from "./md5";
 
 export type Bindings = {
   DB: D1Database;
@@ -71,7 +72,7 @@ type CircleRow = {
   ips: string | null;
 };
 
-type LinkRow = { participation_id: number; kind: string; label: string; url: string; sort_order: number };
+type LinkRow = { id: number; participation_id: number; kind: string; label: string; url: string; sort_order: number };
 type TweetRow = {
   participation_id: number;
   url: string;
@@ -126,7 +127,7 @@ function serializeCircle(row: CircleRow, links: LinkRow[], tweet?: TweetRow) {
     status: row.status,
     links: links
       .filter((l) => l.participation_id === row.participation_id)
-      .sort((a, b) => a.sort_order - b.sort_order)
+      .sort((a, b) => a.sort_order - b.sort_order || a.id - b.id)
       .map((l) => ({ kind: l.kind, label: l.label, url: l.url })),
     tweetInfo: tweet
       ? {
@@ -275,12 +276,13 @@ app.get("/events", async (c) => {
     }),
   );
   const { results } = await c.env.DB.prepare(
-    "SELECT id, slug, title, alias, fare_id, date_label, start_date, end_date, venue, map_url, status FROM events ORDER BY start_date DESC"
+    "SELECT id, slug, title, alias, fare_id, date_label, start_date, end_date, venue, map_url, status FROM events ORDER BY start_date DESC, id DESC"
   ).all<EventStatusRow & Record<string, unknown>>();
   const today = new Date().toISOString().slice(0, 10);
-  return c.json({
-    events: results.map((event) => ({ ...event, status: determineEventStatus(event, today) })),
-  });
+  const events = results.map((event) => ({ ...event, status: determineEventStatus(event, today) }));
+  const meta = { schemaVersion: 1, hash: await md5Hex(JSON.stringify(events)) };
+  if (c.req.query("metadata") === "1") return c.json({ meta });
+  return c.json({ events, meta });
 });
 
 app.post("/events", async (c) => {
@@ -337,7 +339,7 @@ app.get("/circles", async (c) => {
      FROM participations p
      JOIN circles c ON c.id = p.circle_id
      WHERE p.event_id = ? AND c.event_id = p.event_id AND (? = 'all' OR p.status = ?)
-     ORDER BY c.name`
+     ORDER BY c.name, c.id`
   )
     .bind(eventId, statusFilter, statusFilter)
     .all<CircleRow>();
@@ -363,7 +365,9 @@ app.get("/circles", async (c) => {
   }
 
   const circles = filteredRows.map((r) => serializeCircle(r, links, tweets.find((t) => t.participation_id === r.participation_id)));
-  return c.json({ circles });
+  const meta = { schemaVersion: 1, hash: await md5Hex(JSON.stringify(circles)) };
+  if (c.req.query("metadata") === "1") return c.json({ meta });
+  return c.json({ circles, meta });
 });
 
 app.get("/circles/:slug", async (c) => {

--- a/worker/md5.ts
+++ b/worker/md5.ts
@@ -1,0 +1,62 @@
+// MD5 is used only as a deterministic change fingerprint, never for security.
+// This small implementation keeps the Worker independent of Node-only crypto APIs.
+export async function md5Hex(input: string): Promise<string> {
+  const bytes = new TextEncoder().encode(input);
+  const bitLength = bytes.length * 8;
+  const paddedLength = (((bytes.length + 8) >> 6) + 1) * 64;
+  const message = new Uint8Array(paddedLength);
+  message.set(bytes);
+  message[bytes.length] = 0x80;
+  const view = new DataView(message.buffer);
+  view.setUint32(paddedLength - 8, bitLength >>> 0, true);
+  view.setUint32(paddedLength - 4, Math.floor(bitLength / 0x100000000), true);
+
+  let a0 = 0x67452301;
+  let b0 = 0xefcdab89;
+  let c0 = 0x98badcfe;
+  let d0 = 0x10325476;
+  const k = Array.from({ length: 64 }, (_, i) => Math.floor(Math.abs(Math.sin(i + 1)) * 2 ** 32) >>> 0);
+  const s = [7, 12, 17, 22, 5, 9, 14, 20, 4, 11, 16, 23, 6, 10, 15, 21];
+
+  for (let offset = 0; offset < message.length; offset += 64) {
+    const words = Array.from({ length: 16 }, (_, i) => view.getUint32(offset + i * 4, true));
+    let a = a0;
+    let b = b0;
+    let c = c0;
+    let d = d0;
+
+    for (let i = 0; i < 64; i++) {
+      let f: number;
+      let g: number;
+      if (i < 16) {
+        f = (b & c) | (~b & d);
+        g = i;
+      } else if (i < 32) {
+        f = (d & b) | (~d & c);
+        g = (5 * i + 1) % 16;
+      } else if (i < 48) {
+        f = b ^ c ^ d;
+        g = (3 * i + 5) % 16;
+      } else {
+        f = c ^ (b | ~d);
+        g = (7 * i) % 16;
+      }
+      const rotate = s[(i % 4) + (i < 16 ? 0 : i < 32 ? 4 : i < 48 ? 8 : 12)];
+      const next = d;
+      d = c;
+      c = b;
+      b = (b + (((a + f + k[i] + words[g]) >>> 0 << rotate) | ((a + f + k[i] + words[g]) >>> 0 >>> (32 - rotate)))) >>> 0;
+      a = next;
+    }
+
+    a0 = (a0 + a) >>> 0;
+    b0 = (b0 + b) >>> 0;
+    c0 = (c0 + c) >>> 0;
+    d0 = (d0 + d) >>> 0;
+  }
+
+  const output = new Uint8Array(16);
+  const result = new DataView(output.buffer);
+  [a0, b0, c0, d0].forEach((word, i) => result.setUint32(i * 4, word, true));
+  return Array.from(output, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}


### PR DESCRIPTION
## Summary

- 행사 목록과 행사별 서클 API에 서버 계산 MD5 metadata를 추가했습니다.
- localStorage에 schemaVersion/hash/data/cachedAt 캐시 봉투를 저장하고, 해시가 같으면 전체 데이터 요청을 생략합니다.
- 캐시 손상·네트워크 실패 fallback과 행사별 방문 체크 저장을 보강했습니다.
- 로그인 사용자는 localStorage 저장을 유지하면서 기존 원격 체크 동기화도 계속 사용합니다.

Closes #59

## Verification

- `npm test` — 112 passed, 1 skipped
- `npm run typecheck`
- `npm run build`
- `git diff --check`
