### PR TITLE
feat: 방문 체크 원격 동기화 및 충돌 해결 (#61)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ npm run preview # 빌드 결과 미리보기
 | code | HTTP | 의미 |
 | --- | --- | --- |
 | `unauthorized` | 401 | Bearer 토큰 누락/불일치 (쓰기 요청) |
+| `forbidden` | 403 | 세션 쿠키를 사용하는 변경 요청의 출처가 허용되지 않음 |
 | `invalid_request` | 400 | 잘못된 입력·JSON·content-type (DB 변경 없이 거절) |
 | `not_found` | 404 | 대상 event/circle/participation 없음 |
 | `internal` | 500 | 처리되지 않은 서버 오류 |
@@ -55,6 +56,24 @@ npm run preview # 빌드 결과 미리보기
 `gbc-seoko-cache:v1:events`, 행사별 서클을
 `gbc-seoko-cache:v1:circles:<eventSlug>`에 `schemaVersion/hash/data/cachedAt` 형태로 저장한다.
 로그인 정보와 세션 쿠키는 이 저장 구조에 포함하지 않는다.
+
+## 방문 체크 동기화
+
+`GET /api/checks?event=<slug>` 응답은 `{ checks, updatedAt }`를 반환한다.
+`updatedAt`은 서버가 발급한 UTC ISO-8601 밀리초 시각이며, 브라우저는 기존
+체크 키(`gbc-seoko-checks:<eventSlug>`)와 별도 메타 키
+`gbc-seoko-checks-meta:<eventSlug>`에 함께 저장한다. 로그인 후에는 로컬 체크를
+먼저 표시한 다음 두 시각을 비교해 더 최신 상태를 사용한다. 시각이 같으면
+원격 상태를 우선한다.
+
+`PUT /api/checks`는 최신 요청만 원자적으로 반영한다. 서버는 저장 시각을 직접
+발급하고, 오래된 요청·동일 시각 요청은 `{ saved: false, conflict: "stale" }`로
+현재 원격 상태를 반환한다. 클라이언트 시각이 서버보다 과도하게 앞서면
+`conflict: "clock_skew"`로 거절해 잘못된 미래 시각이 원격 데이터를 덮어쓰지
+못하게 한다. 네트워크 오류 때는 로컬 상태를 유지하고 브라우저가 온라인으로
+돌아오면 다시 동기화한다.
+로그아웃하면 브라우저에 남은 행사별 체크와 동기화 메타데이터를 지워 다음 계정으로
+잘못 전송되지 않게 한다.
 
 ## Cloudflare 배포
 ### 방법 A — Workers (권장)

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -58,7 +58,10 @@
 
 ## 5. 상태
 
-- 방문 체크는 `localStorage["gbc-seoko-2026-07-checks"]`에 저장(기존 키 유지).
+- 방문 체크는 `localStorage["gbc-seoko-checks:<eventSlug>"]`에 행사별로 저장하고,
+  동기화 시각은 `gbc-seoko-checks-meta:<eventSlug>`에 저장한다.
+- 로그인 사용자는 서버 `updatedAt`을 기준으로 최신 상태를 선택한다. 같은 시각은
+  원격 우선이며, 서버는 조건부 UPDATE로 오래된 요청의 덮어쓰기를 막는다.
 - 필터(상태/장르)·검색은 클라이언트 상태. 카드 탭 → 상세, 뒤로가기 → 목록.
 
 ## 6. 모션

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { Settings, useTheme } from "./components/Settings";
 import { InstallBanner } from "./components/InstallGuide";
 import { useInstallPrompt } from "./hooks/useInstallPrompt";
 import { eventSubtitle } from "./lib/event";
+import { clearAllChecks } from "./lib/checks";
 
 /* ---------- 앱 ---------- */
 export default function App() {
@@ -28,7 +29,7 @@ export default function App() {
     if (merged > 0) setAnnounce(`${merged}개 항목을 동기화했어요`);
   }, []);
   const handleSyncError = useCallback(() => setAnnounce("방문 체크를 저장하지 못했어요"), []);
-  const [checks, toggle] = useChecks(event?.slug ?? null, event?.status === "active", !!user, authLoading, handleSync, handleSyncError);
+  const [checks, toggle] = useChecks(event?.slug ?? null, event?.status === "active", !!user, authLoading, handleSync, handleSyncError, user?.userId ?? null);
   const [theme, setTheme] = useTheme();
   const install = useInstallPrompt();
   const [status, setStatus] = useState<Status>("all");
@@ -61,7 +62,11 @@ export default function App() {
 
   // 워커가 쿠키를 지우므로 revoke 결과와 무관하게 클라이언트는 로그아웃 상태로 전환한다.
   const handleLogout = useCallback(() => {
-    void logout().catch(() => {}).finally(() => { setUser(null); setSyncedAt(null); });
+    void logout().catch(() => {}).finally(() => {
+      clearAllChecks(localStorage);
+      setUser(null);
+      setSyncedAt(null);
+    });
   }, []);
 
   // 행사장 서클 + 통판(unlisted)을 한 데이터셋으로 다뤄 검색·필터·체크를 일관 적용

--- a/src/api.ts
+++ b/src/api.ts
@@ -178,17 +178,23 @@ export async function fetchChecks(eventSlug: string): Promise<ChecksResponse> {
   return await res.json();
 }
 
-export async function saveChecks(eventSlug: string, checks: Record<string, boolean>): Promise<void> {
+export async function saveChecks(eventSlug: string, checks: Record<string, boolean>, updatedAt?: string | null): Promise<ChecksResponse> {
   const res = await fetch(`/api/checks?event=${encodeURIComponent(eventSlug)}`, {
     method: "PUT",
     credentials: "include",
     headers: { "content-type": "application/json" },
-    body: JSON.stringify({ checks }),
+    body: JSON.stringify({ checks, ...(updatedAt ? { updatedAt } : {}) }),
   });
   if (!res.ok) throw new Error("방문 체크를 저장하지 못했어요");
+  return await res.json();
 }
 
-type ChecksResponse = { checks: Record<string, boolean> };
+export type ChecksResponse = {
+  checks: Record<string, boolean>;
+  updatedAt: string | null;
+  saved?: boolean;
+  conflict?: "stale" | "clock_skew";
+};
 
 export async function fetchCircles(
   eventSlug: string,

--- a/src/hooks/useChecks.ts
+++ b/src/hooks/useChecks.ts
@@ -1,12 +1,30 @@
 import { useEffect, useRef, useState } from "react";
-import { type Checks, loadChecks, saveChecks } from "../lib/checks";
-import { fetchChecks, saveChecks as saveRemoteChecks } from "../api";
+import {
+  type Checks,
+  type ChecksState,
+  compareChecksTimestamps,
+  clearAllChecks,
+  loadChecksState,
+  nextChecksTimestamp,
+  saveChecksState,
+} from "../lib/checks";
+import { fetchChecks, saveChecks as saveRemoteChecks, type ChecksResponse } from "../api";
+
+function checksEqual(a: Checks, b: Checks): boolean {
+  const keys = new Set([...Object.keys(a), ...Object.keys(b)]);
+  return [...keys].every((key) => a[key] === b[key]);
+}
+
+function responseState(response: ChecksResponse): ChecksState {
+  return { checks: response.checks, updatedAt: response.updatedAt ?? null };
+}
 
 /**
- * 행사별 방문 체크 상태. 모든 사용자는 localStorage를 기준으로 사용하고,
- * 로그인 사용자는 321_auth 세션으로 확인한 계정별 원격 저장소에도 저장한다.
- * `onSync(mergedCount)`는 원격 저장이 성공할 때마다 불린다 — 첫 병합은 로컬에서 올라간 체크 개수, 이후 저장은 0.
- * 저장 실패는 `onSyncError`로 알린다(상태는 되돌리지 않는다).
+ * 행사별 방문 체크 상태.
+ *
+ * localStorage의 체크는 항상 먼저 화면에 반영한다. 로그인 상태에서는 서버가
+ * 발급한 UTC 밀리초 시각을 논리 시계로 사용해 원격과 충돌을 해결하고, 저장
+ * 요청은 직렬화해 빠른 연속 토글도 순서대로 서버에 반영한다.
  */
 export function useChecks(
   eventSlug: string | null,
@@ -15,45 +33,174 @@ export function useChecks(
   authLoading = false,
   onSync?: (mergedCount: number) => void,
   onSyncError?: () => void,
+  userId: string | null = null,
 ): [Checks, (id: string) => void] {
   const [checks, setChecks] = useState<Checks>({});
-  const cb = useRef({ onSync, onSyncError });
-  useEffect(() => { cb.current = { onSync, onSyncError }; });
+  const checksRef = useRef(checks);
+  const callbacks = useRef({ onSync, onSyncError });
+  const generation = useRef(0);
+  const revision = useRef(0);
+  const clock = useRef<string | null>(null);
+  const remoteReady = useRef(false);
+  const saveQueue = useRef(Promise.resolve());
+  const activeIdentity = useRef<string | null>(userId);
+  const lastAuthenticatedUser = useRef<string | null>(null);
+  checksRef.current = checks;
+  activeIdentity.current = userId;
+  useEffect(() => { callbacks.current = { onSync, onSyncError }; });
 
   useEffect(() => {
+    const currentGeneration = ++generation.current;
+    const currentUserId = userId;
+    revision.current = 0;
+    clock.current = null;
+    remoteReady.current = false;
+
     if (authLoading || !eventSlug) {
-      if (!eventSlug) setChecks({});
+      if (!eventSlug) {
+        checksRef.current = {};
+        setChecks({});
+      }
       return;
     }
+
+    // The browser storage is intentionally not namespaced by user, so never use
+    // one account's locally synced snapshot as another account's upload source.
+    if (authenticated && currentUserId && lastAuthenticatedUser.current && lastAuthenticatedUser.current !== currentUserId) {
+      clearAllChecks(localStorage);
+    }
+    if (authenticated && currentUserId) lastAuthenticatedUser.current = currentUserId;
+
+    const localState = loadChecksState(localStorage, eventSlug, migrateLegacy);
+    clock.current = localState.updatedAt;
+    checksRef.current = localState.checks;
+    setChecks(localState.checks);
+
     if (!authenticated) {
-      setChecks(loadChecks(localStorage, eventSlug, migrateLegacy));
+      remoteReady.current = true;
       return;
     }
-    const local = loadChecks(localStorage, eventSlug, migrateLegacy);
-    void fetchChecks(eventSlug).then(({ checks: remote }) => {
-      const merged = { ...local, ...remote };
-      setChecks(merged);
-      // 로그인 상태에서도 다음 로드와 로그아웃 이후를 위해 로컬 기준을 최신화한다.
-      saveChecks(localStorage, eventSlug, merged);
-      // 원격과 다른 항목이 있을 때만 올린다 — 단순 로드는 저장도 안내도 없다
-      if (!Object.keys(merged).some((id) => merged[id] !== remote[id])) return;
-      const fromLocal = Object.keys(local).filter((id) => local[id] && !remote[id]).length;
-      void saveRemoteChecks(eventSlug, merged).then(() => cb.current.onSync?.(fromLocal), () => cb.current.onSyncError?.());
-    }).catch(() => setChecks(local));
-  }, [eventSlug, migrateLegacy, authenticated, authLoading]);
 
-  const persist = (next: Checks) => {
+    const isCurrent = () => generation.current === currentGeneration
+      && authenticated
+      && activeIdentity.current === currentUserId;
+    const enqueueSave = (state: ChecksState, capturedRevision: number, mergedCount: number) => {
+      const queued = saveQueue.current.then(async () => {
+        if (!isCurrent()) return;
+        // The timestamp is issued at dispatch time, after all preceding writes.
+        const requestAt = clock.current ? nextChecksTimestamp(clock.current, false) : null;
+        const response = await saveRemoteChecks(eventSlug, state.checks, requestAt);
+        const saved = responseState(response);
+        if (!isCurrent()) return;
+        // Even a superseded request advances the logical clock. The next queued
+        // edit must be newer than the server response it follows.
+        clock.current = saved.updatedAt;
+        if (revision.current !== capturedRevision) return;
+        saveChecksState(localStorage, eventSlug, saved);
+        checksRef.current = saved.checks;
+        setChecks(saved.checks);
+        if (response.saved !== false) callbacks.current.onSync?.(mergedCount);
+      }).catch(() => {
+        if (isCurrent() && revision.current === capturedRevision) callbacks.current.onSyncError?.();
+      });
+      saveQueue.current = queued.catch(() => undefined);
+    };
+
+    const sync = async () => {
+      if (!isCurrent()) return;
+      remoteReady.current = false;
+      try {
+        const remote = await fetchChecks(eventSlug);
+        if (!isCurrent()) return;
+
+        // Read again because the user may have toggled while the GET was pending.
+        const latestLocal = loadChecksState(localStorage, eventSlug, migrateLegacy);
+        const hasLocalSnapshot = localStorage.getItem(`gbc-seoko-checks:${eventSlug}`) !== null;
+        const remoteState = responseState(remote);
+        let desired = remoteState;
+        let shouldUpload = false;
+        let mergedCount = 0;
+
+        if (hasLocalSnapshot && latestLocal.updatedAt === null && !checksEqual(latestLocal.checks, remoteState.checks)) {
+          // Migrate the pre-timestamp format as a logical edit after the server snapshot.
+          desired = { checks: { ...remoteState.checks, ...latestLocal.checks }, updatedAt: null };
+          shouldUpload = true;
+          mergedCount = Object.keys(latestLocal.checks).filter((id) => latestLocal.checks[id] && !remoteState.checks[id]).length;
+        } else {
+          const order = compareChecksTimestamps(latestLocal.updatedAt, remoteState.updatedAt);
+          if (order > 0) {
+            desired = latestLocal;
+            shouldUpload = !checksEqual(latestLocal.checks, remoteState.checks) || latestLocal.updatedAt !== remoteState.updatedAt;
+          } else if (order < 0 || (order === 0 && !checksEqual(latestLocal.checks, remoteState.checks))) {
+            desired = remoteState;
+          }
+        }
+
+        clock.current = desired.updatedAt ?? remoteState.updatedAt;
+        saveChecksState(localStorage, eventSlug, desired);
+        checksRef.current = desired.checks;
+        setChecks(desired.checks);
+        remoteReady.current = true;
+        if (shouldUpload) enqueueSave(desired, revision.current, mergedCount);
+      } catch {
+        if (!isCurrent()) return;
+        // Keep the local snapshot and retry when connectivity is restored.
+        remoteReady.current = false;
+        const fallback = loadChecksState(localStorage, eventSlug, migrateLegacy).checks;
+        checksRef.current = fallback;
+        setChecks(fallback);
+        callbacks.current.onSyncError?.();
+      }
+    };
+
+    void sync();
+    window.addEventListener("online", sync);
+    return () => {
+      window.removeEventListener("online", sync);
+    };
+  }, [eventSlug, migrateLegacy, authenticated, authLoading, userId]);
+
+  const toggle = (id: string) => {
     if (!eventSlug) return;
-    saveChecks(localStorage, eventSlug, next);
-    if (authenticated) void saveRemoteChecks(eventSlug, next).then(() => cb.current.onSync?.(0), () => cb.current.onSyncError?.());
-  };
+    const next = { ...checksRef.current, [id]: !checksRef.current[id] };
+    checksRef.current = next;
+    setChecks(next);
 
-  const toggle = (id: string) =>
-    setChecks((prev) => {
-      const next = { ...prev, [id]: !prev[id] };
-      persist(next);
-      return next;
-    });
+    revision.current += 1;
+    const capturedRevision = revision.current;
+    const capturedGeneration = generation.current;
+    const capturedUserId = userId;
+    // Pending authenticated edits have no committed timestamp yet; the queue
+    // reserves one when it dispatches so rapid toggles cannot share a version.
+    const updatedAt = authenticated ? null : nextChecksTimestamp(clock.current);
+    const state = { checks: next, updatedAt };
+    saveChecksState(localStorage, eventSlug, state);
+    clock.current = updatedAt ?? clock.current;
+
+    if (authenticated && remoteReady.current) {
+      const queued = saveQueue.current.then(async () => {
+        if (generation.current !== capturedGeneration || activeIdentity.current !== capturedUserId || !authenticated) return;
+        const requestAt = clock.current ? nextChecksTimestamp(clock.current, false) : null;
+        const response = await saveRemoteChecks(eventSlug, state.checks, requestAt);
+        const saved = responseState(response);
+        if (generation.current !== capturedGeneration || activeIdentity.current !== capturedUserId) return;
+        clock.current = saved.updatedAt;
+        if (revision.current !== capturedRevision) return;
+        const returned = response.saved === false
+          ? saved
+          : { checks: { ...state.checks, ...saved.checks }, updatedAt: saved.updatedAt };
+        saveChecksState(localStorage, eventSlug, returned);
+        checksRef.current = returned.checks;
+        setChecks(returned.checks);
+        if (response.saved !== false) callbacks.current.onSync?.(0);
+      }).catch(() => {
+        if (generation.current === capturedGeneration && activeIdentity.current === capturedUserId && revision.current === capturedRevision) {
+          callbacks.current.onSyncError?.();
+        }
+      });
+      saveQueue.current = queued.catch(() => undefined);
+    }
+  };
 
   return [checks, toggle];
 }

--- a/src/lib/checks.ts
+++ b/src/lib/checks.ts
@@ -1,5 +1,10 @@
 export type Checks = Record<string, boolean>;
 
+export type ChecksState = {
+  checks: Checks;
+  updatedAt: string | null;
+};
+
 /** localStorage 최소 인터페이스 (테스트에서 가짜 객체 주입 가능). */
 export interface KV {
   getItem(key: string): string | null;
@@ -11,6 +16,18 @@ const LEGACY_KEY = "gbc-seoko-2026-07-checks";
 const MIGRATED_FLAG = "gbc-seoko-checks-migrated";
 
 export const checksKey = (eventSlug: string) => `gbc-seoko-checks:${eventSlug}`;
+export const checksMetaKey = (eventSlug: string) => `gbc-seoko-checks-meta:${eventSlug}`;
+
+export function clearAllChecks(kv: KV): void {
+  const storage = kv as KV & { length?: number; key?: (index: number) => string | null; removeItem?: (key: string) => void };
+  if (typeof storage.length !== "number" || !storage.key) return;
+  const keys = Array.from({ length: storage.length }, (_, index) => storage.key!(index)).filter((key): key is string => Boolean(key));
+  for (const key of keys) {
+    if (!key.startsWith("gbc-seoko-checks:") && !key.startsWith("gbc-seoko-checks-meta:")) continue;
+    if (storage.removeItem) storage.removeItem(key);
+    else storage.setItem(key, "{}");
+  }
+}
 
 function parse(raw: string | null): Checks {
   if (!raw) return {};
@@ -26,21 +43,84 @@ function parse(raw: string | null): Checks {
   }
 }
 
-export function saveChecks(kv: KV, eventSlug: string, checks: Checks): void {
+export function isChecksTimestamp(value: unknown): value is string {
+  if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(value)) return false;
+  return !Number.isNaN(Date.parse(value));
+}
+
+export function compareChecksTimestamps(a: string | null, b: string | null): number {
+  if (a === b) return 0;
+  if (a === null) return -1;
+  if (b === null) return 1;
+  return a < b ? -1 : 1;
+}
+
+/** 서버가 준 시각을 기준으로 다음 논리 시각을 만든다. 인증 상태에서는 이 값을 사용해 클라이언트 시계에 의존하지 않는다. */
+export function nextChecksTimestamp(base: string | null, useWallClock = true): string {
+  const baseTime = base && isChecksTimestamp(base) ? Date.parse(base) : 0;
+  return new Date(Math.max(useWallClock ? Date.now() : 0, baseTime + 1)).toISOString();
+}
+
+function parseState(raw: string | null): ChecksState {
+  if (!raw) return { checks: {}, updatedAt: null };
   try {
-    kv.setItem(checksKey(eventSlug), JSON.stringify(checks));
+    const value = JSON.parse(raw) as unknown;
+    if (value && typeof value === "object" && !Array.isArray(value) && "checks" in value) {
+      const state = value as { checks?: unknown; updatedAt?: unknown };
+      if (typeof state.checks === "object" && state.checks !== null && !Array.isArray(state.checks)) {
+        const checks = parse(JSON.stringify(state.checks));
+        return { checks, updatedAt: isChecksTimestamp(state.updatedAt) ? state.updatedAt : null };
+      }
+    }
+  } catch {
+    // Fall through to the pre-sync checks format.
+  }
+  return { checks: parse(raw), updatedAt: null };
+}
+
+export function saveChecksState(kv: KV, eventSlug: string, state: ChecksState): void {
+  try {
+    // Keep the original checks key backward-compatible. The metadata key is the
+    // authoritative single write for the timestamped pair; the old key is a mirror
+    // for older clients that still read only checksKey().
+    kv.setItem(checksMetaKey(eventSlug), JSON.stringify({ checks: state.checks, updatedAt: state.updatedAt }));
+    kv.setItem(checksKey(eventSlug), JSON.stringify(state.checks));
   } catch {
     /* private mode / quota */
   }
 }
 
-/**
- * 행사별 방문 체크를 불러온다. 새 키가 없고 아직 이관 전이면 레거시 단일 키를
- * 이 행사로 1회 이관한다(호환 정책). 이후 행사는 빈 상태로 시작한다.
- */
-export function loadChecks(kv: KV, eventSlug: string, migrateLegacy = false): Checks {
+export function loadChecksState(kv: KV, eventSlug: string, migrateLegacy = false): ChecksState {
+  const metadataRaw = kv.getItem(checksMetaKey(eventSlug));
+  if (metadataRaw !== null) {
+    try {
+      const metadata = JSON.parse(metadataRaw) as { checks?: unknown };
+      if (metadata && typeof metadata === "object" && typeof metadata.checks === "object" && metadata.checks !== null) {
+        return parseState(metadataRaw);
+      }
+    } catch {
+      // Fall through to the checks key for old or corrupt metadata.
+    }
+  }
   const existing = kv.getItem(checksKey(eventSlug));
-  if (existing !== null) return parse(existing);
+  if (existing !== null) {
+    try {
+      const value = JSON.parse(existing) as { checks?: unknown };
+      if (value && typeof value === "object" && !Array.isArray(value) && typeof value.checks === "object" && value.checks !== null) {
+        return parseState(existing);
+      }
+    } catch {
+      // Fall through to the old checks format.
+    }
+    let updatedAt: string | null = null;
+    try {
+      const metadata = JSON.parse(kv.getItem(checksMetaKey(eventSlug)) || "null") as { updatedAt?: unknown } | null;
+      updatedAt = isChecksTimestamp(metadata?.updatedAt) ? metadata.updatedAt : null;
+    } catch {
+      // Treat malformed metadata as an old, untimestamped local snapshot.
+    }
+    return { checks: parse(existing), updatedAt };
+  }
 
   if (migrateLegacy && kv.getItem(MIGRATED_FLAG) === null) {
     const legacy = kv.getItem(LEGACY_KEY);
@@ -50,10 +130,22 @@ export function loadChecks(kv: KV, eventSlug: string, migrateLegacy = false): Ch
       // private mode / quota; the legacy data can still be read for this load
     }
     if (legacy !== null) {
-      const migrated = parse(legacy);
-      saveChecks(kv, eventSlug, migrated);
+      const migrated = { checks: parse(legacy), updatedAt: null };
+      saveChecksState(kv, eventSlug, migrated);
       return migrated;
     }
   }
-  return {};
+  return { checks: {}, updatedAt: null };
+}
+
+export function saveChecks(kv: KV, eventSlug: string, checks: Checks): void {
+  saveChecksState(kv, eventSlug, { checks, updatedAt: null });
+}
+
+/**
+ * 행사별 방문 체크를 불러온다. 새 키가 없고 아직 이관 전이면 레거시 단일 키를
+ * 이 행사로 1회 이관한다(호환 정책). 이후 행사는 빈 상태로 시작한다.
+ */
+export function loadChecks(kv: KV, eventSlug: string, migrateLegacy = false): Checks {
+  return loadChecksState(kv, eventSlug, migrateLegacy).checks;
 }

--- a/test/client/checks.test.ts
+++ b/test/client/checks.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { loadChecks, saveChecks, checksKey, type KV } from "../../src/lib/checks";
+import { loadChecks, loadChecksState, saveChecks, saveChecksState, checksKey, checksMetaKey, type KV } from "../../src/lib/checks";
 
 function fakeKV(seed: Record<string, string> = {}): KV & { store: Map<string, string> } {
   const store = new Map(Object.entries(seed));
@@ -46,5 +46,14 @@ describe("per-event checks", () => {
   it("ignores check entries that are not booleans", () => {
     const kv = fakeKV({ [checksKey("ev")]: JSON.stringify({ good: true, bad: "yes" }) });
     expect(loadChecks(kv, "ev")).toEqual({});
+  });
+
+  it("keeps the legacy checks key while storing a sync timestamp separately", () => {
+    const kv = fakeKV();
+    saveChecksState(kv, "ev", { checks: { booth: true }, updatedAt: "2026-09-02T06:00:00.123Z" });
+
+    expect(JSON.parse(kv.store.get(checksKey("ev"))!)).toEqual({ booth: true });
+    expect(loadChecksState(kv, "ev")).toEqual({ checks: { booth: true }, updatedAt: "2026-09-02T06:00:00.123Z" });
+    expect(kv.store.has(checksMetaKey("ev"))).toBe(true);
   });
 });

--- a/test/client/useChecks.test.ts
+++ b/test/client/useChecks.test.ts
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useChecks } from "../../src/hooks/useChecks";
+
+const json = (value: unknown) => new Response(JSON.stringify(value), {
+  status: 200,
+  headers: { "content-type": "application/json" },
+});
+
+describe("useChecks remote queue", () => {
+  beforeEach(() => localStorage.clear());
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("dispatches rapid toggles with increasing server-anchored timestamps", async () => {
+    let resolveFirst!: (response: Response) => void;
+    let resolveSecond!: (response: Response) => void;
+    const firstPut = new Promise<Response>((resolve) => { resolveFirst = resolve; });
+    const secondPut = new Promise<Response>((resolve) => { resolveSecond = resolve; });
+    const puts: Record<string, unknown>[] = [];
+    vi.stubGlobal("fetch", vi.fn((url: string, init?: RequestInit) => {
+      if (init?.method === "PUT") {
+        puts.push(JSON.parse(String(init.body)) as Record<string, unknown>);
+        return puts.length === 1 ? firstPut : secondPut;
+      }
+      return Promise.resolve(json({ checks: {}, updatedAt: "2026-09-02T06:00:00.000Z" }));
+    }));
+
+    const { result } = renderHook(() => useChecks("ev", false, true, false, undefined, undefined, "user-1"));
+    await waitFor(() => expect(localStorage.getItem("gbc-seoko-checks-meta:ev")).toContain("06:00:00.000Z"));
+
+    act(() => {
+      result.current[1]("a");
+      result.current[1]("b");
+    });
+    await waitFor(() => expect(puts).toHaveLength(1));
+    expect(puts[0].updatedAt).toBe("2026-09-02T06:00:00.001Z");
+
+    await act(async () => { resolveFirst(json({ checks: { a: true }, updatedAt: "2026-09-02T06:00:00.002Z", saved: true })); });
+    await waitFor(() => expect(puts).toHaveLength(2));
+    expect(puts[1].updatedAt).toBe("2026-09-02T06:00:00.003Z");
+
+    await act(async () => { resolveSecond(json({ checks: { a: true, b: true }, updatedAt: "2026-09-02T06:00:00.004Z", saved: true })); });
+    await waitFor(() => expect(result.current[0]).toEqual({ a: true, b: true }));
+  });
+});

--- a/test/worker/api.test.ts
+++ b/test/worker/api.test.ts
@@ -71,7 +71,52 @@ describe("worker API", () => {
       authEnv,
       {} as ExecutionContext,
     );
-    expect(await loaded.json()).toEqual({ checks: { booth: true } });
+    expect(await loaded.json()).toMatchObject({ checks: { booth: true }, updatedAt: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/) });
+  });
+
+  it("returns updatedAt and rejects stale, equal, and badly skewed check writes", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      new Response(JSON.stringify({ userId: "user-1", email: null, name: null, avatarUrl: null, membership: null }), { status: 200 }),
+    );
+    const authEnv = { ...env, AUTH_ORIGIN: "https://auth.bini59.dev", AUTH_CLIENT_ID: "seoko-maps", AUTH_CLIENT_SECRET: "secret" };
+    const request = (updatedAt: string | null, checks: Record<string, boolean>) => app.fetch(
+      new Request("http://x/api/checks?event=ev", {
+        method: "PUT",
+        headers: { "content-type": "application/json", cookie: "sid=session" },
+        body: JSON.stringify({ checks, ...(updatedAt === null ? {} : { updatedAt }) }),
+      }),
+      authEnv,
+      {} as ExecutionContext,
+    );
+
+    const first = await request(new Date(Date.now() - 2_000).toISOString(), { first: true });
+    expect(first.status).toBe(200);
+    const firstJson = await first.json() as { updatedAt: string };
+    expect(firstJson).toMatchObject({ checks: { first: true }, saved: true });
+    expect(firstJson.updatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+
+    const stale = await request(new Date(Date.parse(firstJson.updatedAt) - 1).toISOString(), { stale: true });
+    expect(await stale.json()).toEqual({ checks: { first: true }, updatedAt: firstJson.updatedAt, saved: false, conflict: "stale" });
+
+    const equal = await request(firstJson.updatedAt, { equal: true });
+    expect(await equal.json()).toEqual({ checks: { first: true }, updatedAt: firstJson.updatedAt, saved: false, conflict: "stale" });
+
+    const skewed = await request("2099-01-01T00:00:00.000Z", { future: true });
+    expect(await skewed.json()).toEqual({ checks: { first: true }, updatedAt: firstJson.updatedAt, saved: false, conflict: "clock_skew" });
+
+    const invalid = await request(null, { invalid: "true" } as unknown as Record<string, boolean>);
+    expect(invalid.status).toBe(400);
+
+    const csrf = await app.fetch(
+      new Request("http://x/api/checks?event=ev", {
+        method: "PUT",
+        headers: { "content-type": "application/json", cookie: "sid=session", origin: "https://evil.example" },
+        body: JSON.stringify({ checks: { csrf: true } }),
+      }),
+      authEnv,
+      {} as ExecutionContext,
+    );
+    expect(csrf.status).toBe(403);
   });
 
   it("logs out via server-side POST to 321_auth and clears the sid cookie (#34)", async () => {

--- a/worker/app.ts
+++ b/worker/app.ts
@@ -90,6 +90,44 @@ type EventStatusRow = {
   status: string;
 };
 
+type UserChecksRow = { checks: string; updated_at: string };
+
+const CHECKS_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+const MAX_CLIENT_CLOCK_AHEAD_MS = 5 * 60 * 1000;
+
+function normalizeChecksTimestamp(value: unknown): string | null {
+  if (typeof value !== "string" || !CHECKS_TIMESTAMP_RE.test(value)) return null;
+  const time = Date.parse(value);
+  return Number.isNaN(time) ? null : new Date(time).toISOString();
+}
+
+function formatStoredChecksTimestamp(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const time = Date.parse(value);
+  return Number.isNaN(time) ? null : new Date(time).toISOString();
+}
+
+function nextServerTimestamp(current: string | null, requested: string | null): string {
+  const now = Date.now();
+  const currentTime = current ? Date.parse(current) : Number.NaN;
+  const requestedTime = requested ? Date.parse(requested) : Number.NaN;
+  return new Date(Math.max(
+    now,
+    Number.isNaN(currentTime) ? 0 : currentTime + 1,
+    Number.isNaN(requestedTime) ? 0 : requestedTime,
+  )).toISOString();
+}
+
+function parseStoredChecks(value: string): Record<string, boolean> {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    return Object.fromEntries(Object.entries(parsed).map(([key, item]) => [key, item === true]));
+  } catch {
+    return {};
+  }
+}
+
 export function determineEventStatus(
   event: Pick<EventStatusRow, "start_date" | "end_date" | "status">,
   today = new Date().toISOString().slice(0, 10),
@@ -142,21 +180,39 @@ function serializeCircle(row: CircleRow, links: LinkRow[], tweet?: TweetRow) {
 }
 
 /** content-type 확인 + JSON 파싱. 실패 시 ValidationError → 일관된 400. */
-async function readJson(c: Context): Promise<Record<string, unknown>> {
+async function readJson(c: Context, maxBytes = 256 * 1024): Promise<Record<string, unknown>> {
   const ct = c.req.header("content-type") || "";
   if (!ct.includes("application/json")) {
     throw new ValidationError("content-type은 application/json이어야 해요");
   }
+  const contentLength = Number(c.req.header("content-length"));
+  if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+    throw new ValidationError("본문이 너무 커요");
+  }
   let body: unknown;
   try {
-    body = await c.req.json();
-  } catch {
+    const raw = await c.req.text();
+    if (new TextEncoder().encode(raw).byteLength > maxBytes) throw new ValidationError("본문이 너무 커요");
+    body = JSON.parse(raw);
+  } catch (error) {
+    if (error instanceof ValidationError) throw error;
     throw new ValidationError("본문이 올바른 JSON이 아니에요");
   }
   if (typeof body !== "object" || body === null || Array.isArray(body)) {
     throw new ValidationError("본문은 JSON 객체여야 해요");
   }
   return body as Record<string, unknown>;
+}
+
+function sessionMutationAllowed(c: Context<{ Bindings: Bindings }>): boolean {
+  const site = c.req.header("sec-fetch-site");
+  const origin = c.req.header("origin");
+  if (site === "cross-site") return false;
+  if (origin && origin !== new URL(c.req.url).origin) {
+    const allowed = (c.env.ALLOWED_ORIGINS || "").split(",").map((item) => item.trim()).filter(Boolean);
+    if (!allowed.includes(origin)) return false;
+  }
+  return true;
 }
 
 export const app = new Hono<{ Bindings: Bindings }>().basePath("/api");
@@ -205,10 +261,7 @@ app.get("/auth/me", async (c) => {
 // 워커가 sid를 대신 넘겨 서버 간 POST로 세션을 revoke하고, 로컬 sid 쿠키를 지운다.
 app.post("/auth/logout", async (c) => {
   // 우리 라우트가 321_auth의 CSRF 가드를 대신 만족시키므로, 타 출처 폼 POST로 강제 로그아웃되지 않게 출처를 확인한다.
-  const site = c.req.header("sec-fetch-site");
-  const origin = c.req.header("origin");
-  const crossSite = (site && site !== "same-origin") || (origin && new URL(origin).host !== new URL(c.req.url).host);
-  if (crossSite) return c.json({ error: "forbidden", code: "forbidden" }, 403);
+  if (!sessionMutationAllowed(c)) return c.json({ error: "forbidden", code: "forbidden" }, 403);
 
   const sid = /(?:^|;\s*)sid=([A-Za-z0-9._~+/=-]+)/.exec(c.req.header("cookie") ?? "")?.[1];
   let revoked = false;
@@ -242,17 +295,18 @@ app.get("/checks", async (c) => {
   const eventSlug = vSlug(c.req.query("event"), "event");
   const user = await requireAuth(c);
   if (user instanceof Response) return user;
-  const row = await c.env.DB.prepare("SELECT checks FROM user_checks WHERE user_id = ? AND event_slug = ?")
+  const row = await c.env.DB.prepare("SELECT checks, updated_at FROM user_checks WHERE user_id = ? AND event_slug = ?")
     .bind(user.userId, eventSlug)
-    .first<{ checks: string }>();
-  return c.json({ checks: row ? JSON.parse(row.checks) : {} });
+    .first<UserChecksRow>();
+  return c.json({ checks: row ? parseStoredChecks(row.checks) : {}, updatedAt: formatStoredChecksTimestamp(row?.updated_at) });
 });
 
 app.put("/checks", async (c) => {
+  if (!sessionMutationAllowed(c)) return c.json({ error: "forbidden", code: "forbidden" }, 403);
   const eventSlug = vSlug(c.req.query("event"), "event");
   const user = await requireAuth(c);
   if (user instanceof Response) return user;
-  const body = await readJson(c);
+  const body = await readJson(c, 256 * 1024);
   const checks = body.checks;
   if (typeof checks !== "object" || checks === null || Array.isArray(checks)) {
     throw new ValidationError("checks는 JSON 객체여야 해요");
@@ -262,11 +316,69 @@ app.put("/checks", async (c) => {
   if (keys.length > 3000 || keys.some((key) => key.length > 200)) {
     throw new ValidationError("방문 체크 항목이 너무 많거나 길어요");
   }
-  const normalized = Object.fromEntries(keys.map((key) => [key, checkMap[key] === true]));
-  await c.env.DB.prepare(
-    "INSERT INTO user_checks (user_id, event_slug, checks, updated_at) VALUES (?, ?, ?, datetime('now')) ON CONFLICT(user_id, event_slug) DO UPDATE SET checks = excluded.checks, updated_at = excluded.updated_at",
-  ).bind(user.userId, eventSlug, JSON.stringify(normalized)).run();
-  return c.json({ checks: normalized });
+  if (keys.some((key) => typeof checkMap[key] !== "boolean")) {
+    throw new ValidationError("checks의 값은 boolean이어야 해요");
+  }
+  const normalized = checkMap as Record<string, boolean>;
+  const requestedAt = body.updatedAt === undefined || body.updatedAt === null
+    ? null
+    : normalizeChecksTimestamp(body.updatedAt);
+  if (body.updatedAt !== undefined && body.updatedAt !== null && requestedAt === null) {
+    throw new ValidationError("updatedAt은 UTC 밀리초 ISO 시각이어야 해요");
+  }
+
+  // A client timestamp derived from a server response is accepted, but a badly
+  // skewed client clock must not manufacture a future version over current data.
+  if (requestedAt && Date.parse(requestedAt) > Date.now() + MAX_CLIENT_CLOCK_AHEAD_MS) {
+    const current = await c.env.DB.prepare("SELECT checks, updated_at FROM user_checks WHERE user_id = ? AND event_slug = ?")
+      .bind(user.userId, eventSlug)
+      .first<UserChecksRow>();
+    return c.json({
+      checks: current ? parseStoredChecks(current.checks) : {},
+      updatedAt: formatStoredChecksTimestamp(current?.updated_at),
+      saved: false,
+      conflict: "clock_skew",
+    });
+  }
+
+  // The comparison is repeated in the conditional UPDATE, so a request that
+  // races another request cannot overwrite a newer row between SELECT and UPDATE.
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const current = await c.env.DB.prepare("SELECT checks, updated_at FROM user_checks WHERE user_id = ? AND event_slug = ?")
+      .bind(user.userId, eventSlug)
+      .first<UserChecksRow>();
+    const rawCurrentAt = current?.updated_at ?? null;
+    const currentAt = formatStoredChecksTimestamp(rawCurrentAt);
+
+    // Missing timestamps are legacy/unknown writes and are never allowed to
+    // replace an existing server snapshot. They may still create the first row.
+    if (current && currentAt && (!requestedAt || Date.parse(requestedAt) <= Date.parse(currentAt))) {
+      return c.json({ checks: parseStoredChecks(current.checks), updatedAt: currentAt, saved: false, conflict: "stale" });
+    }
+
+    const savedAt = nextServerTimestamp(currentAt, requestedAt);
+    if (!current) {
+      const inserted = await c.env.DB.prepare(
+        "INSERT INTO user_checks (user_id, event_slug, checks, updated_at) VALUES (?, ?, ?, ?) ON CONFLICT(user_id, event_slug) DO NOTHING",
+      ).bind(user.userId, eventSlug, JSON.stringify(normalized), savedAt).run();
+      if (Number((inserted.meta as { changes?: number } | undefined)?.changes ?? 0) > 0) {
+        return c.json({ checks: normalized, updatedAt: savedAt, saved: true });
+      }
+      continue;
+    }
+
+    const updated = await c.env.DB.prepare(
+      "UPDATE user_checks SET checks = ?, updated_at = ? WHERE user_id = ? AND event_slug = ? AND updated_at = ? AND updated_at < ?",
+    ).bind(JSON.stringify(normalized), savedAt, user.userId, eventSlug, rawCurrentAt, savedAt).run();
+    if (Number((updated.meta as { changes?: number } | undefined)?.changes ?? 0) > 0) {
+      return c.json({ checks: normalized, updatedAt: savedAt, saved: true });
+    }
+  }
+
+  const latest = await c.env.DB.prepare("SELECT checks, updated_at FROM user_checks WHERE user_id = ? AND event_slug = ?")
+    .bind(user.userId, eventSlug)
+    .first<UserChecksRow>();
+  return c.json({ checks: latest ? parseStoredChecks(latest.checks) : {}, updatedAt: formatStoredChecksTimestamp(latest?.updated_at), saved: false, conflict: "stale" });
 });
 
 app.get("/events", async (c) => {


### PR DESCRIPTION
## 요약
- 로그인 사용자의 방문 체크에 `updatedAt` 왕복 동기화 추가
- localStorage 우선 표시 후 최신 저장시간 기준으로 원격/로컬 충돌 해결
- 서버 발급 UTC 밀리초 시각과 조건부 CAS로 오래된 동시 요청 차단
- 빠른 연속 토글 큐, 온라인 복구 재동기화, 계정 전환/로그아웃 로컬 데이터 격리
- 체크 API 입력 크기·타입·출처 검증 및 동기화 규칙 문서화

## 검증
- `npm run typecheck`
- `npm test` (14 files, 115 passed, 1 skipped)
- `npm run build`
- `git diff --check`

Closes #61
