### PR TITLE
perf: TanStack Query 도입 및 읽기 데이터 staleTime 최적화

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 - 각 서클의 X(트위터), 통판, 행사 관련 링크를 새 탭으로 열어 확인
 - 행사·서클 응답은 서버 MD5 메타데이터와 버전 캐시를 사용하며, 네트워크가 끊기면 유효한 로컬 캐시로 대체
 
+## 읽기 데이터 캐시 역할
+
+- TanStack Query는 런타임 메모리에서 읽기 데이터를 재사용한다. 행사 목록은 `['events']`, 행사별 서클은 `['circles', eventSlug]` 키를 사용하며 `staleTime`은 5분이다.
+- `src/lib/cache.ts`는 API의 MD5와 데이터를 `localStorage`에 저장해 새로고침·오프라인 시 fallback으로 사용한다. 런타임 Query 캐시와 브라우저 영속 캐시는 서로 다른 역할이다.
+- 화면 데이터는 단일 fetch 함수 경로를 `queryFn`으로 거쳐 Query에서 공급하며, 화면이 API나 `localStorage`를 직접 읽지 않는다.
+
 ## 로컬 실행
 ```bash
 npm install

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "gbc-seoko-2026-07",
       "version": "1.3.1",
       "dependencies": {
+        "@tanstack/react-query": "^5.102.8",
         "hono": "^4.12.27",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
@@ -3829,6 +3830,32 @@
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.102.8",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.102.8.tgz",
+      "integrity": "sha512-ZNjkJ33CqvPNec/6lZBnHqLc3EVGPZ9ySLhYahU9TcuRFdmwXewuj0c4hwSWcGHqEUwcSrKeZ+oGcvPBqXcQcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.102.8",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.102.8.tgz",
+      "integrity": "sha512-TYBea4OuXWD7MhaSHq069TWbFe7rcwWN6kzT7JF0OKi1K6c1gTv2IzD6A6ExJsCMozdkqBWeuIUZmu4KQg0O5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.102.8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "db:seed:local": "wrangler d1 execute gbc-seoko-db --local --file=seeds/dev.sql"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.102.8",
     "hono": "^4.12.27",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,8 @@ import { useInstallPrompt } from "./hooks/useInstallPrompt";
 import { eventSubtitle } from "./lib/event";
 import { clearAllChecks } from "./lib/checks";
 
+const READ_STALE_TIME = 5 * 60 * 1000;
+
 /* ---------- 앱 ---------- */
 export default function App() {
   const { route, openEvents, openEvent, openCircle, backToEvent, openSettings } = useAppRoute();
@@ -44,7 +46,7 @@ export default function App() {
   const eventsQuery = useQuery({
     queryKey: ["events"],
     queryFn: ({ signal }) => fetchEvents(signal),
-    staleTime: 5 * 60 * 1000,
+    staleTime: READ_STALE_TIME,
     retry: false,
     enabled: routeMode !== "settings",
   });
@@ -69,7 +71,7 @@ export default function App() {
   const circlesQuery = useQuery({
     queryKey: ["circles", eventSlug],
     queryFn: ({ signal }) => fetchCircles(eventSlug!, signal),
-    staleTime: 5 * 60 * 1000,
+    staleTime: READ_STALE_TIME,
     retry: false,
     enabled: isChecklistRoute && eventSlug !== null,
   });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { Circle } from "./types";
-import { fetchAuth, fetchCircles, fetchEvents, logout, pickActiveEvent, type ApiEvent, type AuthUser } from "./api";
+import { useQuery } from "@tanstack/react-query";
+import { fetchAuth, fetchCircles, fetchEvents, logout, pickActiveEvent, type AuthUser } from "./api";
 import { badgeColor, filterCircles, STATUS, type Status } from "./lib/circle";
 import { useChecks } from "./hooks/useChecks";
 import { useAppRoute } from "./hooks/useAppRoute";
@@ -17,8 +17,6 @@ import { clearAllChecks } from "./lib/checks";
 /* ---------- 앱 ---------- */
 export default function App() {
   const { route, openEvents, openEvent, openCircle, backToEvent, openSettings } = useAppRoute();
-  const [events, setEvents] = useState<ApiEvent[]>([]);
-  const [event, setEvent] = useState<ApiEvent | null>(null);
   const [authEnabled, setAuthEnabled] = useState(false);
   const [authLoading, setAuthLoading] = useState(true);
   const [user, setUser] = useState<AuthUser | null>(null);
@@ -29,7 +27,6 @@ export default function App() {
     if (merged > 0) setAnnounce(`${merged}개 항목을 동기화했어요`);
   }, []);
   const handleSyncError = useCallback(() => setAnnounce("방문 체크를 저장하지 못했어요"), []);
-  const [checks, toggle] = useChecks(event?.slug ?? null, event?.status === "active", !!user, authLoading, handleSync, handleSyncError, user?.userId ?? null);
   const [theme, setTheme] = useTheme();
   const install = useInstallPrompt();
   const [status, setStatus] = useState<Status>("all");
@@ -41,14 +38,54 @@ export default function App() {
   const pendingSheet = useRef<Exclude<Sheet, null> | null>(null);
   const searchRef = useRef<HTMLInputElement>(null);
 
-  const [circles, setCircles] = useState<Circle[]>([]);
-  const [witchformExtra, setWitchformExtra] = useState<Circle[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [loadError, setLoadError] = useState<string | null>(null);
-  const loadGeneration = useRef(0);
-  const loadController = useRef<AbortController | null>(null);
   const requestedEventSlug = route.kind === "event" || route.kind === "circle" ? route.eventSlug : null;
   const routeMode = route.kind === "events" ? "events" : route.kind === "settings" ? "settings" : route.kind === "legacy-circle" ? "legacy" : "event";
+
+  const eventsQuery = useQuery({
+    queryKey: ["events"],
+    queryFn: ({ signal }) => fetchEvents(signal),
+    staleTime: 5 * 60 * 1000,
+    retry: false,
+    enabled: routeMode !== "settings",
+  });
+  const events = eventsQuery.data ?? [];
+  const routeEvent = routeMode === "legacy"
+    ? pickActiveEvent(events)
+    : routeMode === "event"
+      ? events.find((candidate) => candidate.slug === requestedEventSlug) ?? null
+      : null;
+  const currentEventSlug = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (routeMode === "events") currentEventSlug.current = null;
+    else if (routeEvent) currentEventSlug.current = routeEvent.slug;
+  }, [routeEvent, routeMode]);
+
+  const event = routeMode === "settings"
+    ? events.find((candidate) => candidate.slug === currentEventSlug.current) ?? null
+    : routeEvent;
+  const eventSlug = event?.slug ?? null;
+  const isChecklistRoute = routeMode === "event" || routeMode === "legacy";
+  const circlesQuery = useQuery({
+    queryKey: ["circles", eventSlug],
+    queryFn: ({ signal }) => fetchCircles(eventSlug!, signal),
+    staleTime: 5 * 60 * 1000,
+    retry: false,
+    enabled: isChecklistRoute && eventSlug !== null,
+  });
+  const circles = circlesQuery.data?.circles ?? [];
+  const witchformExtra = circlesQuery.data?.witchformExtra ?? [];
+  const missingEvent = isChecklistRoute && eventsQuery.isSuccess && !event;
+  const queryError = eventsQuery.error ?? circlesQuery.error;
+  const loadError = missingEvent
+    ? "행사 정보를 찾지 못했어요"
+    : queryError instanceof Error
+      ? queryError.message
+      : queryError
+        ? "불러오기 실패"
+        : null;
+  const loading = routeMode !== "settings" && (eventsQuery.isFetching || circlesQuery.isFetching);
+  const [checks, toggle] = useChecks(event?.slug ?? null, event?.status === "active", !!user, authLoading, handleSync, handleSyncError, user?.userId ?? null);
 
   const loadAuth = useCallback(() => {
     void fetchAuth().then(({ enabled, user: currentUser }) => {
@@ -71,54 +108,6 @@ export default function App() {
 
   // 행사장 서클 + 통판(unlisted)을 한 데이터셋으로 다뤄 검색·필터·체크를 일관 적용
   const all = useMemo(() => [...circles, ...witchformExtra], [circles, witchformExtra]);
-
-  const load = useCallback(async () => {
-    const generation = ++loadGeneration.current;
-    loadController.current?.abort();
-    const controller = new AbortController();
-    loadController.current = controller;
-    try {
-      if (routeMode === "settings") {
-        setLoading(false);
-        return;
-      }
-      setLoading(true);
-      setLoadError(null);
-      setEvent(null);
-      setCircles([]);
-      setWitchformExtra([]);
-      const available = await fetchEvents(controller.signal);
-      if (generation !== loadGeneration.current) return;
-      setEvents(available);
-      if (routeMode === "events") {
-        setEvent(null);
-        setCircles([]);
-        setWitchformExtra([]);
-        return;
-      }
-      const requestedSlug = routeMode === "legacy"
-        ? pickActiveEvent(available)?.slug
-        : requestedEventSlug;
-      const ev = available.find((candidate) => candidate.slug === requestedSlug);
-      if (!ev) throw new Error("행사 정보를 찾지 못했어요");
-      const { circles: cs, witchformExtra: wf } = await fetchCircles(ev.slug, controller.signal);
-      if (generation !== loadGeneration.current) return;
-      setEvent(ev);
-      setCircles(cs);
-      setWitchformExtra(wf);
-    } catch (e) {
-      if (generation !== loadGeneration.current) return;
-      if (e instanceof DOMException && e.name === "AbortError") return;
-      setLoadError(e instanceof Error ? e.message : "불러오기 실패");
-    } finally {
-      if (generation === loadGeneration.current) setLoading(false);
-    }
-  }, [requestedEventSlug, routeMode]);
-
-  useEffect(() => {
-    void load();
-    return () => loadController.current?.abort();
-  }, [load]);
 
   useEffect(() => {
     loadAuth();
@@ -403,7 +392,7 @@ export default function App() {
                   <div className="text-center py-14" role="alert">
                     <div className="text-danger text-sm font-semibold">{loadError}</div>
                     <button
-                      onClick={() => void load()}
+                      onClick={() => void (eventsQuery.error || missingEvent ? eventsQuery.refetch() : circlesQuery.refetch())}
                       disabled={loading}
                       className="mt-3 inline-flex items-center h-9 px-4 rounded-full bg-ink text-bg text-[13px] font-bold cursor-pointer border-0 disabled:opacity-60"
                     >

--- a/src/api.ts
+++ b/src/api.ts
@@ -66,7 +66,8 @@ async function requestJson(url: string, signal?: AbortSignal): Promise<{ respons
   let body: unknown;
   try {
     body = await response.json();
-  } catch {
+  } catch (error) {
+    if (isAbort(error)) throw error;
     body = null;
   }
   return { response, body };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,13 +1,24 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import App from "./App";
 import "./index.css";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+    },
+  },
+});
 
 const root = document.getElementById("root");
 if (!root) throw new Error("#root not found");
 
 ReactDOM.createRoot(root).render(
   <React.StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
   </React.StrictMode>
 );

--- a/test/client/App.test.tsx
+++ b/test/client/App.test.tsx
@@ -1,7 +1,10 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { render, screen, fireEvent, cleanup, waitFor, act, within } from "@testing-library/react";
+import { render as rtlRender, screen, fireEvent, cleanup, waitFor, act, within } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import App from "../../src/App";
+import { cacheKeys } from "../../src/lib/cache";
 
 type ApiCircleLike = Record<string, unknown>;
 
@@ -18,6 +21,10 @@ const apiCircle = (o: Partial<ApiCircleLike> & { slug: string; name: string; sta
   links: [],
   ...o,
 });
+
+function json(obj: unknown) {
+  return new Response(JSON.stringify(obj), { status: 200, headers: { "content-type": "application/json" } });
+}
 
 function mockApi(circles: ApiCircleLike[], authEnabled = false, user: { userId: string; email: null; name: string; avatarUrl: null } | null = null) {
   const json = (obj: unknown) =>
@@ -39,6 +46,21 @@ function mockApi(circles: ApiCircleLike[], authEnabled = false, user: { userId: 
       throw new Error("unexpected fetch " + url);
     }),
   );
+}
+
+/** Keep App tests independent: every render gets an isolated client with no automatic retries. */
+function render(ui: ReactElement) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return rtlRender(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+}
+
+function goTo(hash: string) {
+  window.location.hash = hash;
+  fireEvent(window, new Event("hashchange"));
+}
+
+function cached<T>(hash: string, data: T) {
+  return JSON.stringify({ schemaVersion: 1, hash, cachedAt: Date.now(), data });
 }
 
 const CIRCLES = [
@@ -267,7 +289,7 @@ describe("<App/> confirmed + unlisted", () => {
     fireEvent.click(screen.getByRole("button", { name: "걸즈밴드크라이" }));
     window.location.hash = "#/events/illustar";
     fireEvent(window, new Event("hashchange"));
-    await screen.findByText("일러스타 페스");
+    await screen.findByText("부스서클");
     expect((screen.getByRole("searchbox") as HTMLInputElement).value).toBe("");
     expect(screen.getByRole("button", { name: "전체" }).getAttribute("aria-pressed")).toBe("true");
     expect(screen.getByRole("button", { name: "전체 장르" }).getAttribute("aria-pressed")).toBe("true");
@@ -281,7 +303,7 @@ describe("<App/> confirmed + unlisted", () => {
 
     window.location.hash = "#/events/illustar";
     fireEvent(window, new Event("hashchange"));
-    await screen.findByText("일러스타 페스");
+    await screen.findByText("부스서클");
     expect(screen.getAllByLabelText("방문 체크").length).toBeGreaterThan(0);
     expect(localStorage.getItem("gbc-seoko-checks:illustar")).toBeNull();
   });
@@ -326,6 +348,152 @@ describe("<App/> confirmed + unlisted", () => {
     expect(await screen.findByRole("alert")).toBeTruthy();
     expect(screen.queryByText("부스서클")).toBeNull();
     expect(screen.queryByLabelText("방문 체크")).toBeNull();
+  });
+
+  it("reuses the events and circles query caches when re-entering within five minutes", async () => {
+    const hash = "a".repeat(32);
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === "/api/events?metadata=1") return json({ meta: { schemaVersion: 1, hash } });
+      if (url === "/api/events") return json({ events: [
+        { id: 1, slug: "ev", title: "캐시 행사", status: "active" },
+      ], meta: { schemaVersion: 1, hash } });
+      if (url === "/api/circles?event=ev&status=all&metadata=1") return json({ meta: { schemaVersion: 1, hash } });
+      if (url === "/api/circles?event=ev&status=all") return json({
+        circles: [apiCircle({ slug: "cached-circle", name: "첫 로드 서클", status: "confirmed" })],
+        meta: { schemaVersion: 1, hash },
+      });
+      if (url === "/api/auth/me") return json({ enabled: false, user: null });
+      throw new Error("unexpected fetch " + url);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    goTo("#/events/ev");
+    render(<App />);
+    await screen.findByText("첫 로드 서클");
+    expect(fetchMock.mock.calls.filter(([url]) => url === "/api/events").length).toBe(1);
+    expect(fetchMock.mock.calls.filter(([url]) => url === "/api/events?metadata=1").length).toBe(1);
+    expect(fetchMock.mock.calls.filter(([url]) => url === "/api/circles?event=ev&status=all").length).toBe(1);
+
+    goTo("#/");
+    await screen.findByRole("heading", { name: "행사 선택" });
+    goTo("#/events/ev");
+    await screen.findByText("첫 로드 서클");
+
+    expect(fetchMock.mock.calls.filter(([url]) => url === "/api/events").length).toBe(1);
+    expect(fetchMock.mock.calls.filter(([url]) => url === "/api/events?metadata=1").length).toBe(1);
+    expect(fetchMock.mock.calls.filter(([url]) => url === "/api/circles?event=ev&status=all").length).toBe(1);
+  });
+
+  it("isolates circle caches by event slug and restores the matching cached dataset", async () => {
+    const eventHash = "b".repeat(32);
+    const evCircle = apiCircle({ slug: "ev-circle", name: "코믹 서클", status: "confirmed" });
+    const illustarCircle = apiCircle({ slug: "illustar-circle", name: "일러스타 서클", status: "confirmed" });
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === "/api/events?metadata=1") return json({ meta: { schemaVersion: 1, hash: eventHash } });
+      if (url === "/api/events") return json({ events: [
+        { id: 1, slug: "ev", title: "코믹월드", status: "active" },
+        { id: 2, slug: "illustar", title: "일러스타 페스", status: "upcoming" },
+      ], meta: { schemaVersion: 1, hash: eventHash } });
+      if (url === "/api/circles?event=ev&status=all&metadata=1") return json({ meta: { schemaVersion: 1, hash: "c".repeat(32) } });
+      if (url === "/api/circles?event=ev&status=all") return json({ circles: [evCircle] });
+      if (url === "/api/circles?event=illustar&status=all&metadata=1") return json({ meta: { schemaVersion: 1, hash: "d".repeat(32) } });
+      if (url === "/api/circles?event=illustar&status=all") return json({ circles: [illustarCircle] });
+      if (url === "/api/auth/me") return json({ enabled: false, user: null });
+      throw new Error("unexpected fetch " + url);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    goTo("#/events/ev");
+    render(<App />);
+    await screen.findByText("코믹 서클");
+
+    goTo("#/events/illustar");
+    await screen.findByText("일러스타 서클");
+    expect(screen.queryByText("코믹 서클")).toBeNull();
+
+    goTo("#/events/ev");
+    await screen.findByText("코믹 서클");
+    expect(screen.queryByText("일러스타 서클")).toBeNull();
+    expect(fetchMock.mock.calls.filter(([url]) => url === "/api/circles?event=ev&status=all").length).toBe(1);
+    expect(fetchMock.mock.calls.filter(([url]) => url === "/api/circles?event=illustar&status=all").length).toBe(1);
+  });
+
+  it("revalidates metadata and refreshes both datasets after staleTime expires", async () => {
+    const initialHash = "e".repeat(32);
+    const refreshedHash = "f".repeat(32);
+    let version = 1;
+    const fetchMock = vi.fn((url: string) => {
+      const hash = version === 1 ? initialHash : refreshedHash;
+      if (url === "/api/events?metadata=1") return json({ meta: { schemaVersion: 1, hash } });
+      if (url === "/api/events") return json({ events: [
+        { id: 1, slug: "ev", title: version === 1 ? "첫 행사 버전" : "새 행사 버전", status: "active" },
+      ], meta: { schemaVersion: 1, hash } });
+      if (url === "/api/circles?event=ev&status=all&metadata=1") return json({ meta: { schemaVersion: 1, hash } });
+      if (url === "/api/circles?event=ev&status=all") return json({ circles: [apiCircle({
+        slug: "versioned-circle",
+        name: version === 1 ? "이전 데이터" : "새 데이터",
+        status: "confirmed",
+      })], meta: { schemaVersion: 1, hash } });
+      if (url === "/api/auth/me") return json({ enabled: false, user: null });
+      throw new Error("unexpected fetch " + url);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const initialNow = Date.now();
+    vi.useFakeTimers({ now: initialNow });
+    try {
+      goTo("#/events/ev");
+      render(<App />);
+      for (let i = 0; i < 100; i += 1) {
+        await act(async () => { await vi.advanceTimersByTimeAsync(1); });
+        await Promise.resolve();
+      }
+      expect(screen.getByText("이전 데이터")).toBeTruthy();
+      await act(async () => { await vi.advanceTimersByTimeAsync(5 * 60 * 1000 + 1); });
+      vi.setSystemTime(initialNow + 5 * 60 * 1000 + 1);
+      version = 2;
+      goTo("#/settings");
+      expect(screen.getByRole("heading", { name: "설정" })).toBeTruthy();
+      await act(async () => { await Promise.resolve(); });
+      goTo("#/events/ev");
+      await act(async () => {
+        for (let i = 0; i < 100; i += 1) {
+          await vi.advanceTimersByTimeAsync(1);
+          await Promise.resolve();
+        }
+      });
+      expect(screen.getByText("새 데이터")).toBeTruthy();
+    } finally {
+      vi.useRealTimers();
+    }
+
+    expect(fetchMock.mock.calls.filter(([url]) => url === "/api/events?metadata=1").length).toBe(2);
+    expect(fetchMock.mock.calls.filter(([url]) => url === "/api/events").length).toBe(2);
+    expect(fetchMock.mock.calls.filter(([url]) => url === "/api/circles?event=ev&status=all&metadata=1").length).toBe(2);
+    expect(fetchMock.mock.calls.filter(([url]) => url === "/api/circles?event=ev&status=all").length).toBe(2);
+  });
+
+  it("uses matching local metadata caches without downloading either full dataset", async () => {
+    const eventsHash = "1".repeat(32);
+    const circlesHash = "2".repeat(32);
+    const cachedEvent = { id: 1, slug: "ev", title: "로컬 캐시 행사", status: "active" };
+    const cachedCircle = { id: "local-circle", name: "로컬 캐시 서클", links: [] };
+    localStorage.setItem(cacheKeys.events, cached(eventsHash, [cachedEvent]));
+    localStorage.setItem(cacheKeys.circles("ev"), cached(circlesHash, { circles: [cachedCircle], witchformExtra: [] }));
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === "/api/events?metadata=1") return json({ meta: { schemaVersion: 1, hash: eventsHash } });
+      if (url === "/api/circles?event=ev&status=all&metadata=1") return json({ meta: { schemaVersion: 1, hash: circlesHash } });
+      if (url === "/api/auth/me") return json({ enabled: false, user: null });
+      throw new Error("full dataset should not be requested: " + url);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    goTo("#/events/ev");
+    render(<App />);
+    await screen.findByText("로컬 캐시 서클");
+    expect(fetchMock.mock.calls.filter(([url]) => url === "/api/events")).toHaveLength(0);
+    expect(fetchMock.mock.calls.filter(([url]) => url === "/api/circles?event=ev&status=all")).toHaveLength(0);
+    expect(fetchMock.mock.calls.filter(([url]) => String(url).includes("metadata=1"))).toHaveLength(2);
   });
 });
 

--- a/test/client/App.test.tsx
+++ b/test/client/App.test.tsx
@@ -27,8 +27,6 @@ function json(obj: unknown) {
 }
 
 function mockApi(circles: ApiCircleLike[], authEnabled = false, user: { userId: string; email: null; name: string; avatarUrl: null } | null = null) {
-  const json = (obj: unknown) =>
-    new Response(JSON.stringify(obj), { status: 200, headers: { "content-type": "application/json" } });
   vi.stubGlobal(
     "fetch",
     vi.fn(async (url: string) => {

--- a/test/client/App.test.tsx
+++ b/test/client/App.test.tsx
@@ -463,6 +463,7 @@ describe("<App/> confirmed + unlisted", () => {
         }
       });
       expect(screen.getByText("새 데이터")).toBeTruthy();
+      expect(screen.getAllByText("새 행사 버전").length).toBeGreaterThan(0);
     } finally {
       vi.useRealTimers();
     }

--- a/test/client/a11y-routing.test.tsx
+++ b/test/client/a11y-routing.test.tsx
@@ -1,6 +1,8 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
+import { render as rtlRender, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import App from "../../src/App";
 import { circleHash, parseRoute } from "../../src/lib/route";
 
@@ -20,6 +22,12 @@ const CIRCLES = [
 
 function json(obj: unknown) {
   return new Response(JSON.stringify(obj), { status: 200, headers: { "content-type": "application/json" } });
+}
+
+/** Keep App tests independent: every render gets an isolated client with no automatic retries. */
+function render(ui: ReactElement) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return rtlRender(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
 }
 
 describe("<App/> accessibility + routing", () => {
@@ -115,5 +123,38 @@ describe("<App/> accessibility + routing", () => {
     const retry = await screen.findByRole("button", { name: /다시 시도/ });
     fireEvent.click(retry);
     expect(await screen.findByText("부스서클")).toBeTruthy();
+  });
+
+  it("does not retry beyond the metadata/data pair, while manual retry recovers", async () => {
+    let eventRequests = 0;
+    let circleRequests = 0;
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === "/api/events?metadata=1" || url === "/api/events") {
+        eventRequests += 1;
+        if (eventRequests <= 2) throw new Error("네트워크 오류");
+        return url.endsWith("metadata=1")
+          ? json({ meta: { schemaVersion: 1, hash: "a".repeat(32) } })
+          : json({ events: [EVENT], meta: { schemaVersion: 1, hash: "a".repeat(32) } });
+      }
+      if (url === "/api/circles?event=ev&status=all&metadata=1" || url === "/api/circles?event=ev&status=all") {
+        circleRequests += 1;
+        return url.endsWith("metadata=1")
+          ? json({ meta: { schemaVersion: 1, hash: "b".repeat(32) } })
+          : json({ circles: CIRCLES, meta: { schemaVersion: 1, hash: "b".repeat(32) } });
+      }
+      if (url === "/api/auth/me") return json({ enabled: false, user: null });
+      throw new Error("unexpected " + url);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    window.location.hash = "#/events/ev";
+
+    render(<App />);
+    const retry = await screen.findByRole("button", { name: "다시 시도" });
+    expect(eventRequests).toBe(2);
+    expect(circleRequests).toBe(0);
+    fireEvent.click(retry);
+    expect(await screen.findByText("부스서클")).toBeTruthy();
+    expect(eventRequests).toBe(4);
+    expect(circleRequests).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary
- 행사 목록과 행사별 서클 읽기 데이터를 TanStack Query로 전환했습니다.
- `['events']`, `['circles', eventSlug]` query key와 5분 staleTime을 적용했습니다.
- 기존 MD5/localStorage 캐시 fallback과 방문 체크 동기화 로직을 유지했습니다.
- query cache 재사용, 행사별 격리, staleTime 만료 갱신, retry/abort/라우팅 회귀 테스트를 추가했습니다.

## Verification
- `npm ci`
- `npm run typecheck`
- `npm test` — 120 passed, 1 skipped
- `npm run build`
- `git diff --check`

Closes #63
