### PR TITLE
refactor: TanStack 쿼리 정의를 lib/queries.ts로 통합, auth를 useQuery로 전환

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,8 +33,9 @@ export default function App() {
   }, []);
   const handleSyncError = useCallback(() => setAnnounce("방문 체크를 저장하지 못했어요"), []);
 
-  const eventsQuery = useQuery({ ...eventsOptions(), enabled: route.kind !== "settings" });
-  const events = eventsQuery.data ?? [];
+  // 화면들도 같은 쿼리를 각자 구독한다(캐시 공유). 여기서는 체크 동기화에 필요한 현재 행사만 해석한다.
+  // 설정 화면에서는 새 구독자가 없어 stale 데이터를 재조회하지 않는다.
+  const { data: events = [] } = useQuery({ ...eventsOptions(), enabled: route.kind !== "settings" });
   const requestedEventSlug = route.kind === "event" || route.kind === "circle" ? route.eventSlug : null;
   const routeEvent = route.kind === "legacy-circle"
     ? pickActiveEvent(events)
@@ -95,9 +96,6 @@ export default function App() {
   const navContext = route.kind === "settings" ? "settings" : route.kind === "events" ? "events" : "event";
   const showNav = route.kind !== "circle" && route.kind !== "legacy-circle";
 
-  const eventsError = eventsQuery.error;
-  const eventsLoadError = eventsError instanceof Error ? eventsError.message : eventsError ? "불러오기 실패" : null;
-
   return (
     // 쉘: 모바일은 단일 컬럼(560px), md 이상은 사이드바 + 콘텐츠 2컬럼. 컴포넌트는 공유하고 레이아웃만 분기.
     <div className="min-h-screen bg-bg flex flex-col md:grid md:grid-cols-[260px_minmax(0,1fr)]">
@@ -105,7 +103,6 @@ export default function App() {
         {announce}
       </div>
       <Sidebar
-        events={events}
         currentSlug={requestedEventSlug !== null ? eventSlug : null}
         showOnMobile={route.kind === "events"}
         settingsActive={route.kind === "settings"}
@@ -115,13 +112,11 @@ export default function App() {
         {route.kind === "settings" ? (
           <SettingsScreen authEnabled={authEnabled} user={user} syncedAt={syncedAt} theme={theme} onTheme={setTheme} onLogout={handleLogout} install={install} />
         ) : route.kind === "events" ? (
-          <EventsScreen install={install} onOpenSettings={openSettings} loadError={eventsLoadError} loading={eventsQuery.isFetching} empty={events.length === 0} />
+          <EventsScreen install={install} onOpenSettings={openSettings} />
         ) : (
           <ChecklistScreen
             event={event}
             circleSlug={route.kind === "circle" || route.kind === "legacy-circle" ? route.circleSlug : null}
-            events={events}
-            eventsQuery={eventsQuery}
             checks={checks}
             onToggle={handleToggle}
             filters={filters}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
-import { fetchAuth, fetchEvents, logout, pickActiveEvent, type AuthUser } from "./api";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { logout, pickActiveEvent } from "./api";
 import { useChecks } from "./hooks/useChecks";
 import { useAppRoute } from "./hooks/useAppRoute";
 import { useChecklistFilters } from "./hooks/useChecklistFilters";
@@ -12,14 +12,15 @@ import { ChecklistScreen } from "./screens/ChecklistScreen";
 import { EventsScreen } from "./screens/EventsScreen";
 import { SettingsScreen } from "./screens/SettingsScreen";
 import { clearAllChecks } from "./lib/checks";
-import { READ_STALE_TIME } from "./lib/query";
+import { authQuery, eventsQuery as eventsOptions, SIGNED_OUT } from "./lib/queries";
 
 /* ---------- 앱 쉘: 라우트 → 화면 분기, 사이드바/하단 네비, 인증, 체크 동기화 ---------- */
 export default function App() {
   const { route, openEvents, openEvent, openCircle, openSettings } = useAppRoute();
-  const [authEnabled, setAuthEnabled] = useState(false);
-  const [authLoading, setAuthLoading] = useState(true);
-  const [user, setUser] = useState<AuthUser | null>(null);
+  const queryClient = useQueryClient();
+  const auth = useQuery(authQuery());
+  const { enabled: authEnabled, user } = auth.data ?? SIGNED_OUT;
+  const authLoading = auth.isPending;
   const [syncedAt, setSyncedAt] = useState<number | null>(null);
   const [announce, setAnnounce] = useState("");
   const [theme, setTheme] = useTheme();
@@ -32,13 +33,7 @@ export default function App() {
   }, []);
   const handleSyncError = useCallback(() => setAnnounce("방문 체크를 저장하지 못했어요"), []);
 
-  const eventsQuery = useQuery({
-    queryKey: ["events"],
-    queryFn: ({ signal }) => fetchEvents(signal),
-    staleTime: READ_STALE_TIME,
-    retry: false,
-    enabled: route.kind !== "settings",
-  });
+  const eventsQuery = useQuery({ ...eventsOptions(), enabled: route.kind !== "settings" });
   const events = eventsQuery.data ?? [];
   const requestedEventSlug = route.kind === "event" || route.kind === "circle" ? route.eventSlug : null;
   const routeEvent = route.kind === "legacy-circle"
@@ -63,24 +58,14 @@ export default function App() {
     toggle(id);
   };
 
-  useEffect(() => {
-    void fetchAuth().then(({ enabled, user: currentUser }) => {
-      setAuthEnabled(enabled);
-      setUser(currentUser);
-    }).catch(() => {
-      setAuthEnabled(false);
-      setUser(null);
-    }).finally(() => setAuthLoading(false));
-  }, []);
-
   // 워커가 쿠키를 지우므로 revoke 결과와 무관하게 클라이언트는 로그아웃 상태로 전환한다.
   const handleLogout = useCallback(() => {
     void logout().catch(() => {}).finally(() => {
       clearAllChecks(localStorage);
-      setUser(null);
+      queryClient.setQueryData(authQuery().queryKey, (prev) => (prev ? { ...prev, user: null } : SIGNED_OUT));
       setSyncedAt(null);
     });
-  }, []);
+  }, [queryClient]);
 
   // 하단 네비와 체크리스트가 공유하는 상태. 네비는 라우트가 바뀌어도 한 인스턴스로 유지돼야 포커스가 살아 있다.
   const filters = useChecklistFilters(requestedEventSlug);

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,3 +1,5 @@
+import { useQuery } from "@tanstack/react-query";
+import { eventsQuery } from "../lib/queries";
 import type { ApiEvent } from "../api";
 import { eventSubtitle } from "../lib/event";
 
@@ -52,18 +54,17 @@ export function EventList({ events, currentSlug }: { events: ApiEvent[]; current
  * 모바일에서는 행사 선택 화면(루트)에서만 본문 아래에 인라인으로 노출된다.
  */
 export function Sidebar({
-  events,
   currentSlug,
   showOnMobile,
   settingsActive,
   onSettings,
 }: {
-  events: ApiEvent[];
   currentSlug: string | null;
   showOnMobile: boolean;
   settingsActive: boolean;
   onSettings: () => void;
 }) {
+  const { data: events = [] } = useQuery(eventsQuery());
   return (
     <aside
       className={

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -1,0 +1,33 @@
+import { queryOptions } from "@tanstack/react-query";
+import { fetchAuth, fetchCircles, fetchEvents } from "../api";
+
+/** 읽기 전용 데이터(events/circles) 캐시 신선도. */
+const READ_STALE_TIME = 5 * 60 * 1000;
+
+// 쿼리 키/옵션의 단일 정의. 화면이 늘어도 같은 데이터는 같은 키를 쓰게 해 캐시가 갈라지지 않도록 한다.
+
+export const eventsQuery = () => queryOptions({
+  queryKey: ["events"],
+  queryFn: ({ signal }) => fetchEvents(signal),
+  staleTime: READ_STALE_TIME,
+  retry: false,
+});
+
+export const circlesQuery = (eventSlug: string | null) => queryOptions({
+  queryKey: ["circles", eventSlug],
+  queryFn: ({ signal }) => fetchCircles(eventSlug!, signal),
+  staleTime: READ_STALE_TIME,
+  retry: false,
+  enabled: eventSlug !== null,
+});
+
+export type AuthState = Awaited<ReturnType<typeof fetchAuth>>;
+export const SIGNED_OUT: AuthState = { enabled: false, user: null };
+
+/** 세션은 로그인/로그아웃 시 setQueryData로 갱신하므로 자동 재조회하지 않는다. 네트워크 실패는 비로그인으로 취급. */
+export const authQuery = () => queryOptions({
+  queryKey: ["auth"],
+  queryFn: () => fetchAuth().catch((): AuthState => SIGNED_OUT),
+  staleTime: Infinity,
+  retry: false,
+});

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -1,2 +1,0 @@
-/** 읽기 전용 데이터(events/circles) 캐시 신선도. */
-export const READ_STALE_TIME = 5 * 60 * 1000;

--- a/src/screens/ChecklistScreen.tsx
+++ b/src/screens/ChecklistScreen.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useMemo, useRef } from "react";
 import { useQuery, type UseQueryResult } from "@tanstack/react-query";
-import { fetchCircles, type ApiEvent } from "../api";
+import type { ApiEvent } from "../api";
 import { badgeColor, filterCircles, STATUS } from "../lib/circle";
 import type { Checks } from "../lib/checks";
 import { eventSubtitle } from "../lib/event";
-import { READ_STALE_TIME } from "../lib/query";
+import { circlesQuery as circlesOptions } from "../lib/queries";
 import { Card } from "../components/Card";
 import { Detail } from "../components/Detail";
 import { EventList } from "../components/Sidebar";
@@ -43,13 +43,7 @@ export function ChecklistScreen({
   const searchRef = useRef<HTMLInputElement>(null);
   const eventSlug = event?.slug ?? null;
 
-  const circlesQuery = useQuery({
-    queryKey: ["circles", eventSlug],
-    queryFn: ({ signal }) => fetchCircles(eventSlug!, signal),
-    staleTime: READ_STALE_TIME,
-    retry: false,
-    enabled: eventSlug !== null,
-  });
+  const circlesQuery = useQuery(circlesOptions(eventSlug));
   const circles = circlesQuery.data?.circles ?? [];
   const witchformExtra = circlesQuery.data?.witchformExtra ?? [];
   const missingEvent = eventsQuery.isSuccess && !event;

--- a/src/screens/ChecklistScreen.tsx
+++ b/src/screens/ChecklistScreen.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useMemo, useRef } from "react";
-import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import type { ApiEvent } from "../api";
 import { badgeColor, filterCircles, STATUS } from "../lib/circle";
 import type { Checks } from "../lib/checks";
 import { eventSubtitle } from "../lib/event";
-import { circlesQuery as circlesOptions } from "../lib/queries";
+import { circlesQuery as circlesOptions, eventsQuery as eventsOptions } from "../lib/queries";
 import { Card } from "../components/Card";
 import { Detail } from "../components/Detail";
 import { EventList } from "../components/Sidebar";
@@ -15,8 +15,6 @@ type Props = {
   /** 라우트가 가리키는 행사. events 로딩 중이거나 slug가 없으면 null. */
   event: ApiEvent | null;
   circleSlug: string | null;
-  events: ApiEvent[];
-  eventsQuery: UseQueryResult<ApiEvent[]>;
   checks: Checks;
   onToggle: (id: string) => void;
   filters: ChecklistFilters;
@@ -36,13 +34,15 @@ const genreChip = (active: boolean) =>
 
 /** 행사 하나의 체크리스트 화면. 필터/시트 상태는 하단 네비와 공유하므로 쉘이 소유하고 props로 받는다. */
 export function ChecklistScreen({
-  event, circleSlug, events, eventsQuery, checks, onToggle, filters, sheet, onSheet: setSheet,
+  event, circleSlug, checks, onToggle, filters, sheet, onSheet: setSheet,
   onOpenEvent, onOpenCircle,
 }: Props) {
   const { status, setStatus, selectedIps, setSelectedIps, query, setQuery } = filters;
   const searchRef = useRef<HTMLInputElement>(null);
   const eventSlug = event?.slug ?? null;
 
+  const eventsQuery = useQuery(eventsOptions());
+  const events = eventsQuery.data ?? [];
   const circlesQuery = useQuery(circlesOptions(eventSlug));
   const circles = circlesQuery.data?.circles ?? [];
   const witchformExtra = circlesQuery.data?.witchformExtra ?? [];

--- a/src/screens/EventsScreen.tsx
+++ b/src/screens/EventsScreen.tsx
@@ -1,22 +1,18 @@
+import { useQuery } from "@tanstack/react-query";
 import { InstallBanner } from "../components/InstallGuide";
 import type { InstallState } from "../hooks/useInstallPrompt";
+import { eventsQuery } from "../lib/queries";
 
-export function EventsScreen({
-  install, onOpenSettings, loadError, loading, empty,
-}: {
-  install: InstallState;
-  onOpenSettings: () => void;
-  loadError: string | null;
-  loading: boolean;
-  empty: boolean;
-}) {
+export function EventsScreen({ install, onOpenSettings }: { install: InstallState; onOpenSettings: () => void }) {
+  const { data: events = [], error, isFetching } = useQuery(eventsQuery());
+  const loadError = error instanceof Error ? error.message : error ? "불러오기 실패" : null;
   return (
     <div className="px-5 pt-7 pb-2 md:px-8 md:py-10">
       <h1 className="text-[26px] font-extrabold text-ink">행사 선택</h1>
       <p className="mt-2 text-sm text-muted">방문할 행사를 골라 관심 서클을 확인하세요.</p>
       <InstallBanner install={install} onOpenSettings={onOpenSettings} />
       {loadError ? <div role="alert" className="mt-8 text-sm text-danger">{loadError}</div> : null}
-      {!loading && !loadError && empty ? <div className="py-14 text-center text-sm text-faint">등록된 행사가 없어요</div> : null}
+      {!isFetching && !loadError && events.length === 0 ? <div className="py-14 text-center text-sm text-faint">등록된 행사가 없어요</div> : null}
     </div>
   );
 }


### PR DESCRIPTION
## 왜
events/circles 쿼리 옵션이 App.tsx와 ChecklistScreen.tsx에 각각 인라인으로 있었고 auth만 useState + 수동 effect였다. 부스/행사 상세 화면이 추가되면 같은 `["circles", slug]` 키를 여러 파일에서 다시 쓰게 되므로, 키·옵션 정의를 한 곳에 둔다.

## 무엇
- `src/lib/queries.ts`: `eventsQuery()`, `circlesQuery(slug)`, `authQuery()`를 `queryOptions()`로 정의. `lib/query.ts`(READ_STALE_TIME) 흡수
- `App.tsx`: `authEnabled/authLoading/user` 상태 3개와 fetchAuth effect → `useQuery(authQuery())` 한 줄. `authLoading = isPending`, 네트워크 실패는 queryFn 안에서 비로그인으로 흡수(기존 catch와 동일 값). `staleTime: Infinity`로 포커스/재마운트 재조회 없음
- 로그아웃: `setUser(null)` → `setQueryData(["auth"], prev => ({...prev, user: null}))`. `enabled`는 유지되므로 연동하기 버튼은 그대로 노출
- StrictMode 이중 마운트 시 `/api/auth/me`가 두 번 나가던 것이 캐시 재사용으로 한 번으로 줄어듦(부수 효과)

## 확인
- typecheck / vitest 121 passed / build 통과
- code-reviewer: auth 로딩·에러 의미, useChecks에 전달되는 (authenticated, authLoading, userId) 전이 순서, 로그아웃 후 UI 모두 기존과 동일 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)