### PR TITLE
feat: 설정 화면에 앱 내 문의·피드백 폼 추가 (GitHub 이슈 링크 대체)

### DIFF
--- a/migrations/0005_feedback.sql
+++ b/migrations/0005_feedback.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS feedback (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  message TEXT NOT NULL,
+  contact TEXT,
+  user_id TEXT,
+  user_agent TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);

--- a/src/api.ts
+++ b/src/api.ts
@@ -235,3 +235,13 @@ export async function fetchCircles(
     },
   }, signal);
 }
+
+export async function sendFeedback(message: string, contact: string): Promise<void> {
+  const res = await fetch("/api/feedback", {
+    method: "POST",
+    credentials: "include",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ message, contact: contact || null }),
+  });
+  if (!res.ok) throw new Error("피드백 전송에 실패했어요");
+}

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1,10 +1,10 @@
 import { useState } from "react";
-import { AUTH_ORIGIN, login, type AuthUser } from "../api";
+import { AUTH_ORIGIN, login, sendFeedback, type AuthUser } from "../api";
 import { InstallGuide } from "./InstallGuide";
 import type { InstallState } from "../hooks/useInstallPrompt";
 
 const ACCOUNT_CENTER_URL = `${AUTH_ORIGIN}/client`;
-const ISSUES_URL = "https://github.com/bini59/317_gbc_seoko/issues";
+const CONTACT_EMAIL = "contact@bini59.dev";
 
 /** 320_archive와 동일 — https 아바타만 허용, 파싱 실패는 null */
 function safeAvatarUrl(value: string | null): string | null {
@@ -22,6 +22,39 @@ function Avatar({ src, fallback }: { src: string | null; fallback: string }) {
     <span className="grid h-9 w-9 shrink-0 place-items-center overflow-hidden rounded-full border border-line bg-chip text-[13px] font-semibold text-muted">
       {src ? <img alt="" src={src} width={36} height={36} referrerPolicy="no-referrer" className="h-full w-full object-cover" /> : fallback}
     </span>
+  );
+}
+
+function FeedbackForm() {
+  const [status, setStatus] = useState<"idle" | "sending" | "sent" | "error">("idle");
+  const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const form = e.currentTarget;
+    const data = new FormData(form);
+    setStatus("sending");
+    try {
+      await sendFeedback(String(data.get("message") ?? ""), String(data.get("contact") ?? ""));
+      form.reset();
+      setStatus("sent");
+    } catch {
+      setStatus("error");
+    }
+  };
+  const fieldCls = "w-full rounded-[8px] border border-line bg-bg px-3 py-2 text-[14px] text-ink placeholder:text-faint";
+  return (
+    <form onSubmit={onSubmit} className="grid gap-2 p-2.5">
+      <textarea name="message" required maxLength={2000} rows={3} placeholder="불편한 점, 잘못된 정보, 바라는 기능을 적어주세요" className={fieldCls} />
+      <input name="contact" type="text" maxLength={200} placeholder="답변 받을 연락처 (선택 · 이메일/트위터)" className={fieldCls} />
+      <div className="flex items-center gap-3">
+        <button type="submit" disabled={status === "sending"} className="h-9 rounded-[8px] bg-ink px-4 text-[13px] font-semibold text-bg disabled:opacity-50">
+          {status === "sending" ? "보내는 중…" : "보내기"}
+        </button>
+        <a href={`mailto:${CONTACT_EMAIL}`} className="text-[12px] text-faint underline">이메일로 보내기</a>
+        <span role="status" className="ml-auto text-[12px] text-muted">
+          {status === "sent" ? "보냈어요. 감사합니다!" : status === "error" ? "전송 실패 — 다시 시도해주세요" : ""}
+        </span>
+      </div>
+    </form>
   );
 }
 
@@ -141,10 +174,13 @@ export function Settings({
         <h3 className={headingCls}>정보</h3>
         <div className="rounded-[14px] border border-line bg-card p-1.5">
           <div className={rowCls + "text-muted"}>앱 버전<span className="ml-auto text-faint">v{import.meta.env.VITE_APP_VERSION ?? "dev"}</span></div>
-          <a href={ISSUES_URL} target="_blank" rel="noreferrer noopener" className={rowCls + "text-muted hover:text-ink"}>
-            <span>문의·피드백<span className="sr-only"> (새 창)</span></span>
-            <External />
-          </a>
+        </div>
+      </section>
+
+      <section className="grid gap-2.5">
+        <h3 className={headingCls}>문의·피드백</h3>
+        <div className="rounded-[14px] border border-line bg-card">
+          <FeedbackForm />
         </div>
       </section>
 

--- a/test/client/Settings.test.tsx
+++ b/test/client/Settings.test.tsx
@@ -7,8 +7,9 @@ import type { InstallState } from "../../src/hooks/useInstallPrompt";
 vi.mock("../../src/api", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../src/api")>()),
   login: vi.fn(),
+  sendFeedback: vi.fn(async () => {}),
 }));
-import { login } from "../../src/api";
+import { login, sendFeedback } from "../../src/api";
 
 const USER = { userId: "u1", email: "seoko@example.com", name: "세오코", avatarUrl: null };
 const noop = () => {};
@@ -39,7 +40,7 @@ describe("<Settings/>", () => {
     expect(screen.getByRole("group", { name: "테마" })).toBeTruthy();
     expect(screen.queryByText("데이터")).toBeNull();
     expect(screen.getByText(/앱 버전/)).toBeTruthy();
-    expect(screen.getByRole("link", { name: /문의·피드백/ }).getAttribute("href")).toBe("https://github.com/bini59/317_gbc_seoko/issues");
+    expect(screen.getByRole("link", { name: "이메일로 보내기" }).getAttribute("href")).toBe("mailto:contact@bini59.dev");
   });
 
   it("signed out: explains sync and calls login() from 연동하기 (#30: no feature-limit copy)", () => {
@@ -108,4 +109,12 @@ describe("<Settings/>", () => {
     expect(screen.queryByRole("button", { name: "홈 화면에 추가" })).toBeNull();
   });
 
+
+  it("submits feedback from the inline form", async () => {
+    render(<Themed />);
+    fireEvent.change(screen.getByPlaceholderText(/불편한 점/), { target: { value: "테스트 피드백" } });
+    fireEvent.submit(screen.getByRole("button", { name: "보내기" }).closest("form")!);
+    await screen.findByText("보냈어요. 감사합니다!");
+    expect(sendFeedback).toHaveBeenCalledWith("테스트 피드백", "");
+  });
 });

--- a/test/helpers/d1.ts
+++ b/test/helpers/d1.ts
@@ -1,5 +1,6 @@
 import { DatabaseSync } from "node:sqlite";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 /**
@@ -9,26 +10,8 @@ import { fileURLToPath } from "node:url";
 export function makeTestDB(): D1Database {
   const db = new DatabaseSync(":memory:");
   db.exec("PRAGMA foreign_keys = ON");
-  const migration = readFileSync(
-    fileURLToPath(new URL("../../migrations/0001_init.sql", import.meta.url)),
-    "utf8",
-  );
-  const eventScopedMigration = readFileSync(
-    fileURLToPath(new URL("../../migrations/0002_event_scoped_circles.sql", import.meta.url)),
-    "utf8",
-  );
-  const ipsMigration = readFileSync(
-    fileURLToPath(new URL("../../migrations/0003_ips_only.sql", import.meta.url)),
-    "utf8",
-  );
-  const userChecksMigration = readFileSync(
-    fileURLToPath(new URL("../../migrations/0004_user_checks.sql", import.meta.url)),
-    "utf8",
-  );
-  db.exec(migration);
-  db.exec(eventScopedMigration);
-  db.exec(ipsMigration);
-  db.exec(userChecksMigration);
+  const dir = fileURLToPath(new URL("../../migrations/", import.meta.url));
+  for (const file of readdirSync(dir).sort()) db.exec(readFileSync(join(dir, file), "utf8"));
   return wrap(db);
 }
 

--- a/test/worker/api.test.ts
+++ b/test/worker/api.test.ts
@@ -37,6 +37,22 @@ describe("worker API", () => {
     expect(r.status).toBe(401);
   });
 
+  it("accepts public feedback without a token and stores it", async () => {
+    const r = await call(env, "POST", "/api/feedback", { message: "  지도가 안 열려요 ", contact: "@me" }, false);
+    expect(r.status).toBe(201);
+    const bad = await call(env, "POST", "/api/feedback", { message: "" }, false);
+    expect(bad.status).toBe(400);
+    const row = await env.DB.prepare("SELECT message, contact, user_id FROM feedback").first();
+    expect(row).toMatchObject({ message: "지도가 안 열려요", contact: "@me", user_id: null });
+  });
+
+  it("forwards feedback by email when the binding is configured", async () => {
+    const send = vi.fn(async () => ({}));
+    const r = await call({ ...env, EMAIL: { send }, FEEDBACK_TO: "contact@bini59.dev" }, "POST", "/api/feedback", { message: "안녕" }, false);
+    expect(r.status).toBe(201);
+    expect(send).toHaveBeenCalledWith(expect.objectContaining({ to: "contact@bini59.dev", subject: "[seoko-maps 피드백] 안녕" }));
+  });
+
   it("returns disabled auth when 321_auth is not configured", async () => {
     const r = await call(env, "GET", "/api/auth/me");
     expect(r.status).toBe(200);

--- a/worker/app.ts
+++ b/worker/app.ts
@@ -23,6 +23,8 @@ export type Bindings = {
   AUTH_ORIGIN?: string;
   AUTH_CLIENT_ID?: string;
   AUTH_CLIENT_SECRET?: string;
+  EMAIL?: SendEmail;
+  FEEDBACK_TO?: string;
 };
 
 type AuthenticatedUser = {
@@ -239,7 +241,7 @@ app.use("*", cors({
 }));
 
 // require bearer token for mutating routes only (session-cookie routes are exempt)
-const SESSION_ROUTES = ["/api/checks", "/api/auth/logout"];
+const SESSION_ROUTES = ["/api/checks", "/api/auth/logout", "/api/feedback"];
 app.use("*", async (c, next) => {
   if (["POST", "PATCH", "PUT", "DELETE"].includes(c.req.method) && !SESSION_ROUTES.includes(c.req.path)) {
     const auth = c.req.header("authorization") || "";
@@ -289,6 +291,31 @@ app.post("/auth/logout", async (c) => {
   const parent = c.env.AUTH_ORIGIN ? new URL(c.env.AUTH_ORIGIN).hostname.split(".").slice(1).join(".") : "";
   if (parent.includes(".")) c.header("set-cookie", `${expired}; Domain=${parent}`, { append: true });
   return c.json({ ok: true, revoked });
+});
+
+// 문의·피드백 — 로그인 불필요. 조회는 `wrangler d1 execute gbc-seoko-db --remote --command "SELECT * FROM feedback ORDER BY id DESC"`.
+// ponytail: 레이트리밋 없음(본문 2000자 + readJson 크기 제한만). 스팸 생기면 Cloudflare WAF rate rule을 /api/feedback에 붙인다.
+app.post("/feedback", async (c) => {
+  const body = await readJson(c, 16 * 1024);
+  const message = str(body.message, "message", 2000);
+  const contact = optStr(body.contact, "contact", 200);
+  const user = await verifyAuth(c).catch(() => null);
+  await c.env.DB.prepare("INSERT INTO feedback (message, contact, user_id, user_agent) VALUES (?, ?, ?, ?)")
+    .bind(message.trim(), contact?.trim() || null, user?.userId ?? null, (c.req.header("user-agent") || "").slice(0, 300))
+    .run();
+  // 메일 전달은 부가 기능 — 바인딩/도메인 미설정이나 실패해도 저장은 이미 끝났으므로 응답에 영향 없음.
+  if (c.env.EMAIL && c.env.FEEDBACK_TO) {
+    const to = c.env.FEEDBACK_TO;
+    c.executionCtx.waitUntil(
+      c.env.EMAIL.send({
+        from: { email: `noreply@${to.split("@")[1]}`, name: "seoko-maps 피드백" },
+        to,
+        subject: `[seoko-maps 피드백] ${message.trim().slice(0, 40)}`,
+        text: `${message.trim()}\n\n연락처: ${contact?.trim() || "(없음)"}\n사용자: ${user?.userId ?? "(비로그인)"}`,
+      }).catch((error) => console.error("feedback email failed", error)),
+    );
+  }
+  return c.json({ ok: true }, 201);
 });
 
 app.get("/checks", async (c) => {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -21,8 +21,10 @@
       "database_id": "b45883c7-c39b-4f96-9640-c41b41792511"
     }
   ],
+  "send_email": [{ "name": "EMAIL" }],
   "vars": {
     "AUTH_ORIGIN": "https://auth.bini59.dev",
-    "AUTH_CLIENT_ID": "seoko-maps"
+    "AUTH_CLIENT_ID": "seoko-maps",
+    "FEEDBACK_TO": "contact@bini59.dev"
   }
 }


### PR DESCRIPTION
## 요약
설정의 "문의·피드백" 메뉴가 GitHub 이슈 페이지로 나가던 것을, 앱 안에서 바로 보내는 폼으로 교체.

- `POST /api/feedback` — 로그인 불필요. `feedback` 테이블(0005 마이그레이션)에 저장, 로그인 상태면 `user_id` 첨부.
- `EMAIL`(send_email) 바인딩 + `FEEDBACK_TO` 변수가 있으면 `contact@bini59.dev`로 메일도 전달. 전송 실패는 로그만 남기고 응답에 영향 없음.
- UI: 메시지 textarea + 선택 연락처 + `mailto:` 보조 링크. 모바일 스크린샷으로 확인.
- 테스트 DB 헬퍼가 `migrations/`를 통째로 로드.

## 배포 시 필요한 것
- [ ] `wrangler d1 migrations apply gbc-seoko-db --remote`
- [ ] `bini59.dev` Email Sending 활성화 여부 확인: `npx wrangler email sending list` (없으면 `enable bini59.dev`). 미설정이면 메일만 안 가고 D1 저장은 됨.

## 스킵한 것
- 레이트리밋 — 스팸 발생 시 WAF rate rule을 `/api/feedback`에 부착 (코드에 `ponytail:` 주석).