### PR TITLE
chore: 피드백 메일 전달 바인딩 비활성화 (D1 저장만 사용)

### DIFF
--- a/test/worker/api.test.ts
+++ b/test/worker/api.test.ts
@@ -30,7 +30,10 @@ describe("worker API", () => {
   beforeEach(() => {
     env = makeEnv();
   });
-  afterEach(() => vi.restoreAllMocks());
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
 
   it("rejects mutations without a valid bearer token", async () => {
     const r = await call(env, "POST", "/api/events", { slug: "e", title: "t" }, false);
@@ -271,6 +274,7 @@ describe("worker API", () => {
   });
 
   it("uses date-derived activity for implicit circle lookups", async () => {
+    vi.useFakeTimers({ now: new Date("2026-09-02T12:00:00Z"), toFake: ["Date"] });
     await call(env, "POST", "/api/events", {
       slug: "current-event",
       title: "현재 행사",

--- a/worker/app.ts
+++ b/worker/app.ts
@@ -303,7 +303,7 @@ app.post("/feedback", async (c) => {
   await c.env.DB.prepare("INSERT INTO feedback (message, contact, user_id, user_agent) VALUES (?, ?, ?, ?)")
     .bind(message.trim(), contact?.trim() || null, user?.userId ?? null, (c.req.header("user-agent") || "").slice(0, 300))
     .run();
-  // 메일 전달은 부가 기능 — 바인딩/도메인 미설정이나 실패해도 저장은 이미 끝났으므로 응답에 영향 없음.
+  // 메일 전달은 선택 — Email Sending이 유료라 현재 꺼둠. 켜려면 wrangler.jsonc에 send_email 바인딩(EMAIL)과 FEEDBACK_TO만 추가.
   if (c.env.EMAIL && c.env.FEEDBACK_TO) {
     const to = c.env.FEEDBACK_TO;
     c.executionCtx.waitUntil(

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -21,10 +21,8 @@
       "database_id": "b45883c7-c39b-4f96-9640-c41b41792511"
     }
   ],
-  "send_email": [{ "name": "EMAIL" }],
   "vars": {
     "AUTH_ORIGIN": "https://auth.bini59.dev",
-    "AUTH_CLIENT_ID": "seoko-maps",
-    "FEEDBACK_TO": "contact@bini59.dev"
+    "AUTH_CLIENT_ID": "seoko-maps"
   }
 }


### PR DESCRIPTION
Email Sending이 유료라 `send_email` 바인딩과 `FEEDBACK_TO`를 제거. 피드백은 D1 `feedback` 테이블에만 저장. 전달 코드는 설정 게이트 뒤에 그대로 두어 나중에 wrangler.jsonc 두 줄로 재활성화 가능.