### PR TITLE
feat: 행사 및 서클 위시리스트 추가

### DIFF
--- a/migrations/0006_user_wishlist.sql
+++ b/migrations/0006_user_wishlist.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS user_wishlist (
+  user_id TEXT NOT NULL,
+  event_slug TEXT NOT NULL,
+  starred INTEGER NOT NULL DEFAULT 0,
+  circles TEXT NOT NULL DEFAULT '{}',
+  starred_at TEXT,
+  circles_updated_at TEXT,
+  PRIMARY KEY (user_id, event_slug)
+);

--- a/migrations/0007_user_wishlist_version.sql
+++ b/migrations/0007_user_wishlist_version.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS user_wishlist_version (
+  user_id TEXT PRIMARY KEY,
+  updated_at TEXT
+);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { logout, pickActiveEvent } from "./api";
 import { useChecks } from "./hooks/useChecks";
@@ -12,9 +12,13 @@ import { ChecklistScreen } from "./screens/ChecklistScreen";
 import { EventsScreen } from "./screens/EventsScreen";
 import { SettingsScreen } from "./screens/SettingsScreen";
 import { clearAllChecks } from "./lib/checks";
-import { authQuery, eventsQuery as eventsOptions, SIGNED_OUT } from "./lib/queries";
+import { clearAllWishlist } from "./lib/wishlist";
+import { useEventWishlist, useCircleWishlist } from "./hooks/useWishlist";
+import { authQuery, circlesQuery as circlesOptions, eventsQuery as eventsOptions, SIGNED_OUT } from "./lib/queries";
 
 /* ---------- 앱 쉘: 라우트 → 화면 분기, 사이드바/하단 네비, 인증, 체크 동기화 ---------- */
+const EMPTY_EVENTS: never[] = [];
+
 export default function App() {
   const { route, openEvents, openEvent, openCircle, openSettings } = useAppRoute();
   const queryClient = useQueryClient();
@@ -26,23 +30,19 @@ export default function App() {
   const [theme, setTheme] = useTheme();
   const install = useInstallPrompt();
 
-  // 원격 저장 완료 시각 + 첫 병합 안내(#45). merged 0 = 단순 저장(안내 없음)
   const handleSync = useCallback((merged: number) => {
     setSyncedAt(Date.now());
     if (merged > 0) setAnnounce(`${merged}개 항목을 동기화했어요`);
   }, []);
   const handleSyncError = useCallback(() => setAnnounce("방문 체크를 저장하지 못했어요"), []);
 
-  // 화면들도 같은 쿼리를 각자 구독한다(캐시 공유). 여기서는 체크 동기화에 필요한 현재 행사만 해석한다.
-  // 설정 화면에서는 새 구독자가 없어 stale 데이터를 재조회하지 않는다.
-  const { data: events = [] } = useQuery({ ...eventsOptions(), enabled: route.kind !== "settings" });
+  const { data: events = EMPTY_EVENTS, isFetched: eventsFetched } = useQuery({ ...eventsOptions(), enabled: route.kind !== "settings" });
   const requestedEventSlug = route.kind === "event" || route.kind === "circle" ? route.eventSlug : null;
   const routeEvent = route.kind === "legacy-circle"
     ? pickActiveEvent(events)
     : requestedEventSlug !== null
       ? events.find((candidate) => candidate.slug === requestedEventSlug) ?? null
       : null;
-  // 설정 화면은 행사 컨텍스트가 URL에 없으므로 마지막 행사를 기억해 체크 동기화와 하단 탭을 이어 준다.
   const lastEventSlug = useRef<string | null>(null);
   useEffect(() => {
     if (route.kind === "events") lastEventSlug.current = null;
@@ -53,25 +53,44 @@ export default function App() {
     : routeEvent;
   const eventSlug = event?.slug ?? null;
 
+  const validEventSlugs = useMemo(
+    () => eventsFetched ? events.map((candidate) => candidate.slug) : null,
+    [events, eventsFetched],
+  );
+  const { data: circleData } = useQuery(circlesOptions(eventSlug));
+  const validCircleIds = useMemo(
+    () => circleData?.circles.concat(circleData.witchformExtra).map((candidate) => candidate.id) ?? null,
+    [circleData],
+  );
   const [checks, toggle] = useChecks(eventSlug, event?.status === "active", !!user, authLoading, handleSync, handleSyncError, user?.userId ?? null);
+  const [eventWishlist, toggleEventWishlist] = useEventWishlist(!!user, user?.userId ?? null, () => setAnnounce("위시리스트를 저장했어요"), () => setAnnounce("위시리스트를 저장하지 못했어요"), validEventSlugs);
+  const circleWishlist = useCircleWishlist(eventSlug, !!user, user?.userId ?? null, () => setAnnounce("위시리스트를 저장했어요"), () => setAnnounce("위시리스트를 저장하지 못했어요"), validCircleIds);
   const handleToggle = (id: string) => {
     setAnnounce(checks[id] ? "방문 체크를 해제했어요" : "방문 체크했어요");
     toggle(id);
   };
+  const handleToggleEventWishlist = (slug: string) => {
+    const isStarred = eventWishlist.includes(slug);
+    setAnnounce(isStarred ? "행사 찜을 해제했어요" : "행사를 찜했어요");
+    toggleEventWishlist(slug);
+  };
+  const handleToggleCircleStar = (id: string) => {
+    const isStarred = !!circleWishlist.circles[id]?.star;
+    setAnnounce(isStarred ? "서클 찜을 해제했어요" : "서클을 찜했어요");
+    circleWishlist.toggleStar(id);
+  };
 
-  // 워커가 쿠키를 지우므로 revoke 결과와 무관하게 클라이언트는 로그아웃 상태로 전환한다.
   const handleLogout = useCallback(() => {
     void logout().catch(() => {}).finally(() => {
       clearAllChecks(localStorage);
+      clearAllWishlist(localStorage);
       queryClient.setQueryData(authQuery().queryKey, (prev) => (prev ? { ...prev, user: null } : SIGNED_OUT));
       setSyncedAt(null);
     });
   }, [queryClient]);
 
-  // 하단 네비와 체크리스트가 공유하는 상태. 네비는 라우트가 바뀌어도 한 인스턴스로 유지돼야 포커스가 살아 있다.
   const filters = useChecklistFilters(requestedEventSlug);
   const [sheet, setSheet] = useState<Sheet>(null);
-  // 라우트가 바뀌면 시트를 닫는다. 설정에서 검색/필터 탭으로 현재 행사에 진입한 경우에는 그 시트를 연다.
   const pendingSheet = useRef<Sheet>(null);
   useEffect(() => {
     setSheet(pendingSheet.current);
@@ -91,7 +110,6 @@ export default function App() {
     if (eventSlug) openEvent(eventSlug);
     else openEvents();
   };
-  // 시트는 행사 체크리스트에서만 존재한다. 라우트 전환 직후의 이전 상태가 한 프레임이라도 남지 않도록 렌더 경계를 둔다.
   const visibleSheet = route.kind === "event" ? sheet : null;
   const navContext = route.kind === "settings" ? "settings" : route.kind === "events" ? "events" : "event";
   const showNav = route.kind !== "circle" && route.kind !== "legacy-circle";
@@ -106,13 +124,15 @@ export default function App() {
         currentSlug={requestedEventSlug !== null ? eventSlug : null}
         showOnMobile={route.kind === "events"}
         settingsActive={route.kind === "settings"}
+        wishlist={eventWishlist}
+        onToggleWishlist={handleToggleEventWishlist}
         onSettings={openSettings}
       />
       <main className={"w-full max-w-[560px] mx-auto border-x border-line md:max-w-none md:mx-0 md:border-x-0 md:min-h-screen " + (route.kind === "events" ? "" : "flex-1")}>
         {route.kind === "settings" ? (
           <SettingsScreen authEnabled={authEnabled} user={user} syncedAt={syncedAt} theme={theme} onTheme={setTheme} onLogout={handleLogout} install={install} />
         ) : route.kind === "events" ? (
-          <EventsScreen install={install} onOpenSettings={openSettings} />
+          <EventsScreen install={install} onOpenSettings={openSettings} wishlist={eventWishlist} onToggleWishlist={handleToggleEventWishlist} />
         ) : (
           <ChecklistScreen
             event={event}
@@ -124,6 +144,11 @@ export default function App() {
             onSheet={setSheet}
             onOpenEvent={openEvent}
             onOpenCircle={openCircle}
+            wishlist={circleWishlist.circles}
+            onToggleStar={handleToggleCircleStar}
+            onUpdateMemo={circleWishlist.updateMemo}
+            eventWishlist={eventWishlist}
+            onToggleEventWishlist={handleToggleEventWishlist}
           />
         )}
       </main>

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,4 @@
-import type { Circle, TweetInfo } from "./types";
+import type { Circle, CircleWishlistMap, CircleWishlistResponse, EventWishlistResponse, TweetInfo } from "./types";
 import type { Checks } from "./lib/checks";
 import { cacheKeys, loadCache, saveCache, type CacheStorage } from "./lib/cache";
 
@@ -196,6 +196,40 @@ export type ChecksResponse = {
   saved?: boolean;
   conflict?: "stale" | "clock_skew";
 };
+
+export async function fetchEventWishlist(): Promise<EventWishlistResponse> {
+  const res = await fetch("/api/wishlist", { credentials: "include" });
+  if (!res.ok) throw new Error("행사 위시리스트를 불러오지 못했어요");
+  return await res.json();
+}
+
+export async function saveEventWishlist(events: string[], updatedAt?: string | null): Promise<EventWishlistResponse> {
+  const res = await fetch("/api/wishlist", {
+    method: "PUT",
+    credentials: "include",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ events, ...(updatedAt ? { updatedAt } : {}) }),
+  });
+  if (!res.ok) throw new Error("행사 위시리스트를 저장하지 못했어요");
+  return await res.json();
+}
+
+export async function fetchCircleWishlist(eventSlug: string): Promise<CircleWishlistResponse> {
+  const res = await fetch(`/api/wishlist?event=${encodeURIComponent(eventSlug)}`, { credentials: "include" });
+  if (!res.ok) throw new Error("서클 위시리스트를 불러오지 못했어요");
+  return await res.json();
+}
+
+export async function saveCircleWishlist(eventSlug: string, circles: CircleWishlistMap, updatedAt?: string | null): Promise<CircleWishlistResponse> {
+  const res = await fetch(`/api/wishlist?event=${encodeURIComponent(eventSlug)}`, {
+    method: "PUT",
+    credentials: "include",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ circles, ...(updatedAt ? { updatedAt } : {}) }),
+  });
+  if (!res.ok) throw new Error("서클 위시리스트를 저장하지 못했어요");
+  return await res.json();
+}
 
 export async function fetchCircles(
   eventSlug: string,

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -9,12 +9,18 @@ export function Card({
   onToggle,
   onOpen,
   color,
+  starred = false,
+  memo,
+  onStar,
 }: {
   item: Circle;
   checked: boolean;
   onToggle: () => void;
   onOpen: () => void;
   color: string;
+  starred?: boolean;
+  memo?: string;
+  onStar?: () => void;
 }) {
   const short = boothShort(item);
   const cardCls = [
@@ -58,6 +64,25 @@ export function Card({
             {item.name}
           </div>
         </button>
+        {onStar && (
+          <button
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              onStar();
+            }}
+            aria-pressed={starred}
+            aria-label={`${item.name} 찜 ${starred ? "해제" : "하기"}`}
+            className={
+              "flex items-center justify-center w-11 h-11 rounded-xl text-lg font-extrabold cursor-pointer transition-colors border " +
+              (starred
+                ? "text-amber-500 border-amber-500/30 bg-amber-500/10"
+                : "text-faint hover:text-muted border-line bg-card hover:bg-chip")
+            }
+          >
+            {starred ? "★" : "☆"}
+          </button>
+        )}
         <button
           onClick={onToggle}
           aria-label={checked ? "방문 체크 해제" : "방문 체크"}
@@ -82,6 +107,8 @@ export function Card({
           )}
         </button>
       </div>
+
+      {memo && <div className="text-[12.5px] text-muted leading-[1.55] mt-[7px] bg-chip rounded-[8px] px-[11px] py-[9px] truncate">{memo}</div>}
 
       {item.note && (
         <div className="text-[12.5px] text-muted leading-[1.55] mt-[7px] bg-chip rounded-[8px] px-[11px] py-[9px]">

--- a/src/components/Detail.tsx
+++ b/src/components/Detail.tsx
@@ -1,30 +1,84 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { Circle } from "../types";
 import { boothShort } from "../lib/circle";
 import { TweetCard } from "./TweetCard";
 
-/* ---------- 상세 화면 ---------- */
 export function Detail({
   item,
   checked,
   onToggle,
   onBack,
   color,
+  starred = false,
+  memo = "",
+  onStar,
+  onUpdateMemo,
 }: {
   item: Circle;
   checked: boolean;
   onToggle: () => void;
   onBack: () => void;
   color: string;
+  starred?: boolean;
+  memo?: string;
+  onStar?: () => void;
+  onUpdateMemo?: (memo: string) => void;
 }) {
   const backRef = useRef<HTMLButtonElement>(null);
-  // 상세 진입 시 포커스를 상세 컨텍스트(뒤로 버튼)로 이동 — 키보드/스크린리더 대응
   useEffect(() => {
     backRef.current?.focus();
   }, [item.id]);
 
+  const [localMemo, setLocalMemo] = useState(memo);
+  const timer = useRef<ReturnType<typeof setTimeout>>();
+  const localMemoRef = useRef(localMemo);
+  localMemoRef.current = localMemo;
+  const onUpdateMemoRef = useRef(onUpdateMemo);
+  onUpdateMemoRef.current = onUpdateMemo;
+  const externalMemoRef = useRef(memo);
+  externalMemoRef.current = memo;
+
+  useEffect(() => {
+    setLocalMemo(memo);
+  }, [item.id, memo]);
+
+  const flushMemo = () => {
+    if (timer.current) {
+      clearTimeout(timer.current);
+      timer.current = undefined;
+    }
+    if (localMemoRef.current !== externalMemoRef.current) {
+      onUpdateMemoRef.current?.(localMemoRef.current);
+    }
+  };
+
+  useEffect(() => {
+    return () => {
+      flushMemo();
+    };
+  }, [item.id]);
+
+  const handleMemoChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const next = e.target.value.slice(0, 500);
+    setLocalMemo(next);
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => {
+      onUpdateMemoRef.current?.(next);
+    }, 300);
+  };
+
+  const handleMemoBlur = () => {
+    flushMemo();
+  };
+
+  const handleStarClick = () => {
+    flushMemo();
+    onStar?.();
+  };
+
   const short = boothShort(item);
   const links: { label: string; url: string; primary: boolean }[] = [];
+
   if (item.boothUrl)
     links.push({
       label: `📍 배치도에서 ${item.booth} 확인`,
@@ -151,8 +205,36 @@ export function Detail({
           </div>
         </div>
 
-        {/* 방문 체크는 스크롤 없이 항상 보이도록 하단 고정 */}
-        <div className="sticky bottom-0 mt-[26px] pt-3 pb-[calc(24px+env(safe-area-inset-bottom))] bg-bg/95 backdrop-blur">
+        {onUpdateMemo && (
+          <div className="mt-6">
+            <label htmlFor="circle-memo" className="text-xs font-extrabold tracking-[0.04em] text-faint">메모</label>
+            <textarea
+              id="circle-memo"
+              maxLength={500}
+              value={localMemo}
+              onChange={handleMemoChange}
+              onBlur={handleMemoBlur}
+              className="mt-2 w-full min-h-24 resize-y rounded-xl border border-line bg-card p-3 text-sm text-ink outline-none"
+            />
+            <div className="mt-1 text-right text-xs text-faint">{localMemo.length}/500</div>
+          </div>
+        )}
+
+        <div className="sticky bottom-0 mt-[26px] pt-3 pb-[calc(24px+env(safe-area-inset-bottom))] bg-bg/95 backdrop-blur flex gap-2">
+          {onStar && (
+            <button
+              type="button"
+              onClick={handleStarClick}
+              aria-pressed={starred}
+              aria-label={`${item.name} 찜 ${starred ? "해제" : "하기"}`}
+              className={
+                "flex items-center justify-center w-[54px] h-[54px] rounded-2xl border text-xl font-extrabold cursor-pointer transition-colors shrink-0 " +
+                (starred ? "text-amber-500 border-amber-500/30 bg-amber-500/10" : "text-faint hover:text-muted border-line bg-card hover:bg-chip")
+              }
+            >
+              {starred ? "★" : "☆"}
+            </button>
+          )}
           <button
             onClick={onToggle}
             className={

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -10,43 +10,104 @@ const EVENT_SECTIONS = [
 ] as const;
 
 /** 행사 목록(진행 중/예정/지난). 데스크톱 사이드바와 모바일 행사 시트가 공유한다. */
-export function EventList({ events, currentSlug }: { events: ApiEvent[]; currentSlug: string | null }) {
-  return EVENT_SECTIONS.map(({ status, label }) => {
-    const matches = events
-      .filter((event) => event.status === status)
-      .sort((a, b) => {
-        const comparison = (a.start_date ?? "").localeCompare(b.start_date ?? "");
-        return status === "past" ? -comparison : comparison;
-      });
-    if (matches.length === 0) return null;
-    return (
-      <section key={status} className="mt-6 md:mt-5">
-        <h2 className="mb-2 text-xs font-extrabold tracking-[0.04em] text-faint">{label}</h2>
-        <div className="flex flex-col gap-3 md:gap-1">
-          {matches.map((candidate) => {
-            const current = candidate.slug === currentSlug;
-            return (
-              <a
-                key={candidate.slug}
-                href={`#/events/${encodeURIComponent(candidate.slug)}`}
-                aria-current={current ? "page" : undefined}
-                className={
-                  "block rounded-[18px] border p-4 no-underline md:rounded-[10px] md:border-transparent md:px-3 md:py-2 " +
-                  (current ? "border-accent/40 bg-accent/10" : "border-line bg-card md:bg-transparent md:hover:bg-chip")
-                }
-              >
-                <div className={"flex items-center gap-1.5 text-[17px] font-extrabold md:text-sm " + (current ? "text-accent" : "text-ink")}>
-                  {current ? <span aria-hidden="true">✓</span> : null}
-                  {candidate.title}
+export function EventList({ events, currentSlug, wishlist = [], onToggleWishlist }: { events: ApiEvent[]; currentSlug: string | null; wishlist?: string[]; onToggleWishlist?: (slug: string) => void }) {
+  const wishlistMatches = events
+    .filter((event) => wishlist.includes(event.slug))
+    .sort((a, b) => (a.start_date ?? "").localeCompare(b.start_date ?? ""));
+
+  return (
+    <>
+      {wishlistMatches.length > 0 && (
+        <section key="wishlist" className="mt-6 md:mt-5">
+          <h2 className="mb-2 text-xs font-extrabold tracking-[0.04em] text-faint">내 위시리스트</h2>
+          <div className="flex flex-col gap-3 md:gap-1">
+            {wishlistMatches.map((candidate) => {
+              const current = candidate.slug === currentSlug;
+              return (
+                <div
+                  key={`wishlist-${candidate.slug}`}
+                  className={
+                    "block rounded-[18px] border p-4 md:rounded-[10px] md:border-transparent md:px-3 md:py-2 " +
+                    (current ? "border-accent/40 bg-accent/10" : "border-line bg-card md:bg-transparent md:hover:bg-chip")
+                  }
+                >
+                  <div className="flex items-center gap-1.5">
+                    <a href={`#/events/${encodeURIComponent(candidate.slug)}`} aria-current={current ? "page" : undefined} className={"min-w-0 flex-1 no-underline text-[17px] font-extrabold md:text-sm " + (current ? "text-accent" : "text-ink")}>
+                      {current ? <span aria-hidden="true">✓</span> : null}
+                      {candidate.title}
+                    </a>
+                    {onToggleWishlist && (
+                      <button
+                        type="button"
+                        onClick={() => onToggleWishlist(candidate.slug)}
+                        aria-pressed={true}
+                        aria-label={`${candidate.title} 행사 찜 해제`}
+                        className="ml-auto flex items-center justify-center w-11 h-11 md:w-8 md:h-8 rounded-xl md:rounded-lg text-lg md:text-base border border-transparent hover:border-line hover:bg-chip cursor-pointer text-amber-500 shrink-0"
+                      >
+                        ★
+                      </button>
+                    )}
+                  </div>
+                  <div className="mt-1 text-xs font-semibold text-faint md:mt-0.5 md:text-[11px]">{eventSubtitle(candidate)}</div>
                 </div>
-                <div className="mt-1 text-xs font-semibold text-faint md:mt-0.5 md:text-[11px]">{eventSubtitle(candidate)}</div>
-              </a>
-            );
-          })}
-        </div>
-      </section>
-    );
-  });
+              );
+            })}
+          </div>
+        </section>
+      )}
+      {EVENT_SECTIONS.map(({ status, label }) => {
+        const matches = events
+          .filter((event) => event.status === status)
+          .sort((a, b) => {
+            const comparison = (a.start_date ?? "").localeCompare(b.start_date ?? "");
+            return status === "past" ? -comparison : comparison;
+          });
+        if (matches.length === 0) return null;
+        return (
+          <section key={status} className="mt-6 md:mt-5">
+            <h2 className="mb-2 text-xs font-extrabold tracking-[0.04em] text-faint">{label}</h2>
+            <div className="flex flex-col gap-3 md:gap-1">
+              {matches.map((candidate) => {
+                const current = candidate.slug === currentSlug;
+                const isStarred = wishlist.includes(candidate.slug);
+                return (
+                  <div
+                    key={candidate.slug}
+                    className={
+                      "block rounded-[18px] border p-4 md:rounded-[10px] md:border-transparent md:px-3 md:py-2 " +
+                      (current ? "border-accent/40 bg-accent/10" : "border-line bg-card md:bg-transparent md:hover:bg-chip")
+                    }
+                  >
+                    <div className="flex items-center gap-1.5">
+                      <a href={`#/events/${encodeURIComponent(candidate.slug)}`} aria-current={current ? "page" : undefined} className={"min-w-0 flex-1 no-underline text-[17px] font-extrabold md:text-sm " + (current ? "text-accent" : "text-ink")}>
+                        {current ? <span aria-hidden="true">✓</span> : null}
+                        {candidate.title}
+                      </a>
+                      {onToggleWishlist && (
+                        <button
+                          type="button"
+                          onClick={() => onToggleWishlist(candidate.slug)}
+                          aria-pressed={isStarred}
+                          aria-label={`${candidate.title} 행사 찜 ${isStarred ? "해제" : "하기"}`}
+                          className={
+                            "ml-auto flex items-center justify-center w-11 h-11 md:w-8 md:h-8 rounded-xl md:rounded-lg text-lg md:text-base border border-transparent hover:border-line hover:bg-chip cursor-pointer shrink-0 " +
+                            (isStarred ? "text-amber-500" : "text-faint hover:text-muted")
+                          }
+                        >
+                          {isStarred ? "★" : "☆"}
+                        </button>
+                      )}
+                    </div>
+                    <div className="mt-1 text-xs font-semibold text-faint md:mt-0.5 md:text-[11px]">{eventSubtitle(candidate)}</div>
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+        );
+      })}
+    </>
+  );
 }
 
 /**
@@ -55,11 +116,15 @@ export function EventList({ events, currentSlug }: { events: ApiEvent[]; current
  */
 export function Sidebar({
   currentSlug,
+  wishlist = [],
+  onToggleWishlist,
   showOnMobile,
   settingsActive,
   onSettings,
 }: {
   currentSlug: string | null;
+  wishlist?: string[];
+  onToggleWishlist?: (slug: string) => void;
   showOnMobile: boolean;
   settingsActive: boolean;
   onSettings: () => void;
@@ -76,7 +141,7 @@ export function Sidebar({
         <a href="#/" className="text-sm font-extrabold text-accent no-underline">걸즈밴드 체크리스트</a>
       </div>
       <nav aria-label="행사" className="flex-1 px-5 pb-6">
-        <EventList events={events} currentSlug={currentSlug} />
+        <EventList events={events} currentSlug={currentSlug} wishlist={wishlist} onToggleWishlist={onToggleWishlist} />
       </nav>
       <div className={(showOnMobile ? "hidden md:block " : "") + "border-t border-line px-5 py-4"}>
         <a href="#/settings" onClick={(e) => { e.preventDefault(); onSettings(); }} aria-current={settingsActive ? "page" : undefined} className={(settingsActive ? "bg-accent/10 text-accent " : "text-muted ") + "flex items-center gap-2 rounded-[10px] px-3 py-2.5 text-xs font-semibold no-underline hover:bg-chip hover:text-ink"}>

--- a/src/hooks/useChecks.ts
+++ b/src/hooks/useChecks.ts
@@ -64,8 +64,6 @@ export function useChecks(
       return;
     }
 
-    // The browser storage is intentionally not namespaced by user, so never use
-    // one account's locally synced snapshot as another account's upload source.
     if (authenticated && currentUserId && lastAuthenticatedUser.current && lastAuthenticatedUser.current !== currentUserId) {
       clearAllChecks(localStorage);
     }
@@ -87,7 +85,6 @@ export function useChecks(
     const enqueueSave = (state: ChecksState, capturedRevision: number, mergedCount: number) => {
       const queued = saveQueue.current.then(async () => {
         if (!isCurrent()) return;
-        // The timestamp is issued at dispatch time, after all preceding writes.
         const requestAt = clock.current ? nextChecksTimestamp(clock.current, false) : null;
         const response = await saveRemoteChecks(eventSlug, state.checks, requestAt);
         const saved = responseState(response);

--- a/src/hooks/useWishlist.ts
+++ b/src/hooks/useWishlist.ts
@@ -1,0 +1,310 @@
+import { useEffect, useRef, useState } from "react";
+import { fetchCircleWishlist, fetchEventWishlist, saveCircleWishlist, saveEventWishlist } from "../api";
+import type { CircleWishlistMap } from "../types";
+import { compareTimestamps, loadCircleWishlistState, loadEventWishlistState, nextWishlistTimestamp, saveCircleWishlistState, saveEventWishlistState, clearAllWishlist } from "../lib/wishlist";
+
+export function useEventWishlist(authenticated: boolean, userId: string | null, onSync?: () => void, onSyncError?: () => void, validEventSlugs: readonly string[] | null = null) {
+  const [events, setEvents] = useState<string[]>([]);
+  const valueRef = useRef(events);
+  const clock = useRef<string | null>(null);
+  const queue = useRef(Promise.resolve());
+  const generation = useRef(0);
+  const revision = useRef(0);
+  const lastAuthenticatedUser = useRef<string | null>(null);
+  const wasAuthenticated = useRef(authenticated);
+  const activeIdentity = useRef<string | null>(userId);
+  const activeAuthenticated = useRef(authenticated);
+  const callbacks = useRef({ onSync, onSyncError });
+  useEffect(() => { callbacks.current = { onSync, onSyncError }; });
+  activeIdentity.current = userId;
+  activeAuthenticated.current = authenticated;
+  valueRef.current = events;
+
+  useEffect(() => {
+    const currentGeneration = ++generation.current;
+    const currentUserId = userId;
+    revision.current = 0;
+    queue.current = Promise.resolve();
+
+    const signedInAfterSignedOut = authenticated && currentUserId && !wasAuthenticated.current;
+    if (signedInAfterSignedOut || (authenticated && currentUserId && lastAuthenticatedUser.current && lastAuthenticatedUser.current !== currentUserId)) {
+      clearAllWishlist(localStorage);
+    }
+    wasAuthenticated.current = authenticated;
+    if (authenticated && currentUserId) lastAuthenticatedUser.current = currentUserId;
+    if (!authenticated) lastAuthenticatedUser.current = null;
+
+    const local = loadEventWishlistState(localStorage);
+    const value = validEventSlugs
+      ? local.value.filter((slug) => validEventSlugs.includes(slug))
+      : local.value;
+    const localWasPruned = value.length !== local.value.length;
+    valueRef.current = value;
+    clock.current = local.updatedAt;
+    setEvents(value);
+    if (value.length !== local.value.length) saveEventWishlistState(localStorage, { value, updatedAt: local.updatedAt });
+    if (!authenticated) return;
+
+    const isCurrent = () => generation.current === currentGeneration && authenticated && activeAuthenticated.current && activeIdentity.current === currentUserId;
+    const enqueue = (value: string[], requestedAt: string | null, capturedRevision: number) => {
+      queue.current = queue.current.then(async () => {
+        if (!isCurrent()) return;
+        const response = await saveEventWishlist(value, requestedAt);
+        if (!isCurrent()) return;
+        clock.current = response.updatedAt;
+        if (revision.current !== capturedRevision) return;
+        const next = response.saved === false ? response.events : value;
+        valueRef.current = next;
+        saveEventWishlistState(localStorage, { value: next, updatedAt: response.updatedAt });
+        setEvents(next);
+        if (response.saved !== false) callbacks.current.onSync?.();
+      }).catch(() => { if (isCurrent() && revision.current === capturedRevision) callbacks.current.onSyncError?.(); });
+    };
+
+    const sync = async () => {
+      try {
+        const remote = await fetchEventWishlist();
+        if (!isCurrent()) return;
+        const current = loadEventWishlistState(localStorage);
+        const remoteEvents = validEventSlugs
+          ? remote.events.filter((slug) => validEventSlugs.includes(slug))
+          : remote.events;
+        const remoteHadDeletedEvents = remoteEvents.length !== remote.events.length;
+        const localNewer = compareTimestamps(current.updatedAt, remote.updatedAt) > 0;
+        const value = localNewer ? current.value : remoteEvents;
+        const updatedAt = localNewer ? current.updatedAt : remote.updatedAt;
+        if (revision.current !== 0) return;
+        valueRef.current = value;
+        clock.current = updatedAt;
+        saveEventWishlistState(localStorage, { value, updatedAt });
+        setEvents(value);
+        if (localNewer || remoteHadDeletedEvents || localWasPruned) enqueue(value, nextWishlistTimestamp(updatedAt, false), revision.current);
+      } catch { if (isCurrent() && revision.current === 0) callbacks.current.onSyncError?.(); }
+    };
+
+    void sync();
+    window.addEventListener("online", sync);
+    return () => window.removeEventListener("online", sync);
+  }, [authenticated, userId, validEventSlugs]);
+
+  const toggle = (slug: string) => {
+    const value = valueRef.current.includes(slug) ? valueRef.current.filter((item) => item !== slug) : [...valueRef.current, slug];
+    const capturedRevision = ++revision.current;
+    const currentGeneration = generation.current;
+    const currentUserId = activeIdentity.current;
+    valueRef.current = value;
+    const updatedAt = nextWishlistTimestamp(clock.current);
+    clock.current = updatedAt;
+    setEvents(value);
+    saveEventWishlistState(localStorage, { value, updatedAt });
+    if (authenticated) {
+      const isCurrent = () => generation.current === currentGeneration && authenticated && activeAuthenticated.current && activeIdentity.current === currentUserId;
+      queue.current = queue.current.then(async () => {
+        if (!isCurrent()) return;
+        const response = await saveEventWishlist(value, updatedAt);
+        if (!isCurrent()) return;
+        clock.current = response.updatedAt;
+        if (revision.current !== capturedRevision) return;
+        const next = response.saved === false ? response.events : value;
+        valueRef.current = next;
+        saveEventWishlistState(localStorage, { value: next, updatedAt: response.updatedAt });
+        setEvents(next);
+        if (response.saved !== false) callbacks.current.onSync?.();
+      }).catch(() => { if (isCurrent() && revision.current === capturedRevision) callbacks.current.onSyncError?.(); });
+    }
+  };
+  return [events, toggle] as const;
+}
+
+export function useCircleWishlist(eventSlug: string | null, authenticated: boolean, userId: string | null, onSync?: () => void, onSyncError?: () => void, validCircleIds: readonly string[] | null = null) {
+  const [circles, setCircles] = useState<CircleWishlistMap>({});
+  const valueRef = useRef(circles);
+  const clock = useRef<string | null>(null);
+  const timer = useRef<ReturnType<typeof setTimeout>>();
+  const pendingSave = useRef<{ value: CircleWishlistMap; updatedAt: string; revision: number; generation: number; slug: string; userId: string; authenticated: boolean } | null>(null);
+  const queue = useRef(Promise.resolve());
+  const generation = useRef(0);
+  const revision = useRef(0);
+  const lastAuthenticatedUser = useRef<string | null>(null);
+  const wasAuthenticated = useRef(authenticated);
+  const activeIdentity = useRef<string | null>(userId);
+  const activeAuthenticated = useRef(authenticated);
+  const activeEventSlug = useRef(eventSlug);
+  const callbacks = useRef({ onSync, onSyncError });
+  useEffect(() => { callbacks.current = { onSync, onSyncError }; });
+  activeIdentity.current = userId;
+  activeAuthenticated.current = authenticated;
+  activeEventSlug.current = eventSlug;
+  valueRef.current = circles;
+
+  const flushPending = () => {
+    if (timer.current) {
+      clearTimeout(timer.current);
+      timer.current = undefined;
+    }
+    const pending = pendingSave.current;
+    if (!pending) return;
+    pendingSave.current = null;
+    const { value, updatedAt, revision: capturedRevision, generation: capturedGen, slug, userId: capturedUserId, authenticated: capturedAuthenticated } = pending;
+    queue.current = queue.current.then(async () => {
+      if (generation.current !== capturedGen || !capturedAuthenticated || !capturedUserId || !activeAuthenticated.current || activeIdentity.current !== capturedUserId || activeEventSlug.current !== slug) return;
+      const response = await saveCircleWishlist(slug, value, updatedAt);
+      if (generation.current !== capturedGen || !capturedAuthenticated || !capturedUserId || !activeAuthenticated.current || activeIdentity.current !== capturedUserId || activeEventSlug.current !== slug) return;
+      clock.current = response.updatedAt;
+      if (revision.current !== capturedRevision) return;
+      const next = response.saved === false ? response.circles : value;
+      valueRef.current = next;
+      saveCircleWishlistState(localStorage, slug, { value: next, updatedAt: response.updatedAt });
+      setCircles(next);
+      if (response.saved !== false) callbacks.current.onSync?.();
+    }).catch(() => {
+      if (generation.current === capturedGen && capturedAuthenticated && activeAuthenticated.current && activeIdentity.current === capturedUserId && activeEventSlug.current === slug && revision.current === capturedRevision) callbacks.current.onSyncError?.();
+    });
+  };
+
+  useEffect(() => {
+    const currentGeneration = ++generation.current;
+    const currentUserId = userId;
+    revision.current = 0;
+    queue.current = Promise.resolve();
+
+    const signedInAfterSignedOut = authenticated && currentUserId && !wasAuthenticated.current;
+    if (signedInAfterSignedOut || (authenticated && currentUserId && lastAuthenticatedUser.current && lastAuthenticatedUser.current !== currentUserId)) {
+      clearAllWishlist(localStorage);
+    }
+    wasAuthenticated.current = authenticated;
+    if (authenticated && currentUserId) lastAuthenticatedUser.current = currentUserId;
+    if (!authenticated) lastAuthenticatedUser.current = null;
+
+    if (!eventSlug) {
+      valueRef.current = {};
+      clock.current = null;
+      setCircles({});
+      return;
+    }
+
+    const local = loadCircleWishlistState(localStorage, eventSlug);
+    const value = validCircleIds ? Object.fromEntries(Object.entries(local.value).filter(([id]) => validCircleIds.includes(id))) : local.value;
+    valueRef.current = value;
+    clock.current = local.updatedAt;
+    setCircles(value);
+    if (Object.keys(value).length !== Object.keys(local.value).length) saveCircleWishlistState(localStorage, eventSlug, { value, updatedAt: local.updatedAt });
+    if (!authenticated) return;
+
+    const isCurrent = () => generation.current === currentGeneration && eventSlug !== null && authenticated && activeIdentity.current === currentUserId;
+    const enqueue = (value: CircleWishlistMap, requestedAt: string | null, capturedRevision: number) => {
+      queue.current = queue.current.then(async () => {
+        if (!isCurrent()) return;
+        const response = await saveCircleWishlist(eventSlug, value, requestedAt);
+        if (!isCurrent()) return;
+        clock.current = response.updatedAt;
+        if (revision.current !== capturedRevision) return;
+        const next = response.saved === false ? response.circles : value;
+        valueRef.current = next;
+        saveCircleWishlistState(localStorage, eventSlug, { value: next, updatedAt: response.updatedAt });
+        setCircles(next);
+        if (response.saved !== false) callbacks.current.onSync?.();
+      }).catch(() => { if (isCurrent() && revision.current === capturedRevision) callbacks.current.onSyncError?.(); });
+    };
+
+    const sync = async () => {
+      try {
+        const remote = await fetchCircleWishlist(eventSlug);
+        if (!isCurrent()) return;
+        const current = loadCircleWishlistState(localStorage, eventSlug);
+        const currentValue = validCircleIds ? Object.fromEntries(Object.entries(current.value).filter(([id]) => validCircleIds.includes(id))) : current.value;
+        const remoteValue = validCircleIds ? Object.fromEntries(Object.entries(remote.circles).filter(([id]) => validCircleIds.includes(id))) : remote.circles;
+        const localNewer = compareTimestamps(current.updatedAt, remote.updatedAt) > 0;
+        const value = localNewer ? currentValue : remoteValue;
+        const updatedAt = localNewer ? current.updatedAt : remote.updatedAt;
+        if (revision.current !== 0) return;
+        valueRef.current = value;
+        clock.current = updatedAt;
+        saveCircleWishlistState(localStorage, eventSlug, { value, updatedAt });
+        setCircles(value);
+        if (localNewer) enqueue(value, nextWishlistTimestamp(updatedAt, false), revision.current);
+      } catch { if (isCurrent() && revision.current === 0) callbacks.current.onSyncError?.(); }
+    };
+
+    void sync();
+    window.addEventListener("online", sync);
+    return () => {
+      window.removeEventListener("online", sync);
+      flushPending();
+    };
+  }, [eventSlug, authenticated, userId, validCircleIds]);
+
+  const toggleStar = (id: string) => {
+    if (!eventSlug) return;
+    flushPending();
+    const prev = valueRef.current[id];
+    const star = !prev?.star;
+    const memo = prev?.memo;
+    const nextEntry = star || memo ? { ...(star ? { star: true } : {}), ...(memo ? { memo } : {}) } : undefined;
+    const nextCircles = { ...valueRef.current };
+    if (nextEntry) nextCircles[id] = nextEntry;
+    else delete nextCircles[id];
+
+    valueRef.current = nextCircles;
+    const updatedAt = nextWishlistTimestamp(clock.current);
+    clock.current = updatedAt;
+    setCircles(nextCircles);
+    saveCircleWishlistState(localStorage, eventSlug, { value: nextCircles, updatedAt });
+
+    if (authenticated) {
+      const capturedRevision = ++revision.current;
+      const currentGeneration = generation.current;
+      const currentEventSlug = eventSlug;
+      const currentUserId = activeIdentity.current;
+      const currentAuthenticated = authenticated;
+      const isCurrent = () => generation.current === currentGeneration
+        && currentEventSlug !== null
+        && currentAuthenticated
+        && activeAuthenticated.current
+        && activeEventSlug.current === currentEventSlug
+        && currentUserId !== null
+        && activeIdentity.current === currentUserId;
+      queue.current = queue.current.then(async () => {
+        if (!isCurrent() || !currentEventSlug) return;
+        const response = await saveCircleWishlist(currentEventSlug, nextCircles, updatedAt);
+        if (!isCurrent()) return;
+        clock.current = response.updatedAt;
+        if (revision.current !== capturedRevision) return;
+        const next = response.saved === false ? response.circles : nextCircles;
+        valueRef.current = next;
+        saveCircleWishlistState(localStorage, currentEventSlug, { value: next, updatedAt: response.updatedAt });
+        setCircles(next);
+        if (response.saved !== false) callbacks.current.onSync?.();
+      }).catch(() => { if (isCurrent() && revision.current === capturedRevision) callbacks.current.onSyncError?.(); });
+    }
+  };
+
+  const updateMemo = (id: string, memo: string) => {
+    if (!eventSlug) return;
+    const trimmed = memo.trim();
+    const prev = valueRef.current[id];
+    const star = prev?.star;
+    const nextEntry = star || trimmed ? { ...(star ? { star: true } : {}), ...(trimmed ? { memo: memo.slice(0, 500) } : {}) } : undefined;
+    const nextCircles = { ...valueRef.current };
+    if (nextEntry) nextCircles[id] = nextEntry;
+    else delete nextCircles[id];
+
+    valueRef.current = nextCircles;
+    const updatedAt = nextWishlistTimestamp(clock.current);
+    clock.current = updatedAt;
+    setCircles(nextCircles);
+    saveCircleWishlistState(localStorage, eventSlug, { value: nextCircles, updatedAt });
+
+    if (authenticated) {
+      if (timer.current) clearTimeout(timer.current);
+      const capturedRevision = ++revision.current;
+      const currentGeneration = generation.current;
+      pendingSave.current = { value: nextCircles, updatedAt, revision: capturedRevision, generation: currentGeneration, slug: eventSlug, userId: activeIdentity.current ?? "", authenticated };
+      timer.current = setTimeout(() => {
+        flushPending();
+      }, 500);
+    }
+  };
+
+  return { circles, toggleStar, updateMemo };
+}

--- a/src/lib/circle.ts
+++ b/src/lib/circle.ts
@@ -1,4 +1,4 @@
-import type { Circle } from "../types";
+import type { Circle, CircleWishlistMap } from "../types";
 
 /* 카드 앞 아이콘(부스 배지) 색상 팔레트 */
 export const BADGE = [
@@ -49,9 +49,10 @@ export const chipsFor = (c: Circle): Chip[] => {
 
 export const norm = (s: string) => s.replace(/\s/g, "");
 
-export type Status = "all" | "done" | "undone";
+export type Status = "all" | "starred" | "done" | "undone";
 export const STATUS: { k: Status; label: string }[] = [
   { k: "all", label: "전체" },
+  { k: "starred", label: "찜한 것" },
   { k: "done", label: "체크함" },
   { k: "undone", label: "안 본 것" },
 ];
@@ -61,13 +62,15 @@ export type CircleFilter = {
   status: Status;
   ips: string[];
   query: string;
+  wishlist?: CircleWishlistMap;
 };
 
-/** 순수 검색/필터/정렬 — React 없이 테스트 가능. */
+
 export function filterCircles(circles: Circle[], f: CircleFilter): Circle[] {
   const q = norm(f.query.toLowerCase());
   return circles
     .filter((c) => {
+      if (f.status === "starred" && !f.wishlist?.[c.id]?.star) return false;
       if (f.status === "done" && !f.checks[c.id]) return false;
       if (f.status === "undone" && f.checks[c.id]) return false;
       if (f.ips.length > 0) {
@@ -76,7 +79,7 @@ export function filterCircles(circles: Circle[], f: CircleFilter): Circle[] {
       }
       if (q) {
         const hay = norm(
-          (c.name + (c.booth || "") + (c.ips || []).join("")).toLowerCase(),
+          (c.name + (c.booth || "") + (c.ips || []).join("") + (f.wishlist?.[c.id]?.memo || "")).toLowerCase(),
         );
         if (!hay.includes(q)) return false;
       }

--- a/src/lib/wishlist.ts
+++ b/src/lib/wishlist.ts
@@ -1,0 +1,66 @@
+import type { CircleWishlistMap } from "../types";
+import type { KV } from "./checks";
+
+export type WishlistState<T> = { value: T; updatedAt: string | null };
+export const eventWishlistKey = "gbc-seoko-event-wishlist";
+export const circleWishlistKey = (eventSlug: string) => `gbc-seoko-wishlist:${eventSlug}`;
+
+function timestamp(value: unknown): string | null {
+  if (typeof value !== "string" || Number.isNaN(Date.parse(value))) return null;
+  return new Date(Date.parse(value)).toISOString();
+}
+
+export function compareTimestamps(a: string | null, b: string | null): number {
+  if (a === b) return 0;
+  if (!a) return -1;
+  if (!b) return 1;
+  return a < b ? -1 : 1;
+}
+
+export function nextWishlistTimestamp(base: string | null, wallClock = true): string {
+  const time = base ? Date.parse(base) : 0;
+  return new Date(Math.max(wallClock ? Date.now() : 0, Number.isNaN(time) ? 0 : time + 1)).toISOString();
+}
+
+function parse<T>(raw: string | null, fallback: T): WishlistState<T> {
+  if (!raw) return { value: fallback, updatedAt: null };
+  try {
+    const data = JSON.parse(raw) as { value?: T; updatedAt?: unknown };
+    return { value: data.value ?? fallback, updatedAt: timestamp(data.updatedAt) };
+  } catch {
+    return { value: fallback, updatedAt: null };
+  }
+}
+
+export function loadEventWishlistState(kv: KV): WishlistState<string[]> {
+  const state = parse<string[]>(kv.getItem(eventWishlistKey), []);
+  return { value: Array.isArray(state.value) ? state.value.filter((item) => typeof item === "string") : [], updatedAt: state.updatedAt };
+}
+
+export function saveEventWishlistState(kv: KV, state: WishlistState<string[]>): void {
+  try { kv.setItem(eventWishlistKey, JSON.stringify(state)); } catch {}
+}
+
+export function pruneCircleWishlist(circles: CircleWishlistMap): CircleWishlistMap {
+  return Object.fromEntries(Object.entries(circles).flatMap(([id, entry]) => {
+    if (!entry || typeof entry !== "object") return [];
+    const memo = typeof entry.memo === "string" ? entry.memo.trim().slice(0, 500) : "";
+    return entry.star === true || memo ? [[id, { ...(entry.star === true ? { star: true } : {}), ...(memo ? { memo } : {}) }]] : [];
+  }));
+}
+
+export function loadCircleWishlistState(kv: KV, eventSlug: string): WishlistState<CircleWishlistMap> {
+  const state = parse<CircleWishlistMap>(kv.getItem(circleWishlistKey(eventSlug)), {});
+  return { value: pruneCircleWishlist(state.value && typeof state.value === "object" ? state.value : {}), updatedAt: state.updatedAt };
+}
+
+export function saveCircleWishlistState(kv: KV, eventSlug: string, state: WishlistState<CircleWishlistMap>): void {
+  try { kv.setItem(circleWishlistKey(eventSlug), JSON.stringify({ value: pruneCircleWishlist(state.value), updatedAt: state.updatedAt })); } catch {}
+}
+
+export function clearAllWishlist(kv: KV): void {
+  const storage = kv as KV & { length?: number; key?: (index: number) => string | null; removeItem?: (key: string) => void };
+  if (typeof storage.length !== "number" || !storage.key) return;
+  const keys = Array.from({ length: storage.length }, (_, i) => storage.key!(i)).filter((key): key is string => Boolean(key));
+  for (const key of keys) if (key === eventWishlistKey || key.startsWith("gbc-seoko-wishlist:")) storage.removeItem?.(key);
+}

--- a/src/screens/ChecklistScreen.tsx
+++ b/src/screens/ChecklistScreen.tsx
@@ -23,6 +23,11 @@ type Props = {
   onSheet: (next: Sheet) => void;
   onOpenEvent: (eventSlug: string) => void;
   onOpenCircle: (eventSlug: string, circleSlug: string) => void;
+  wishlist?: import("../types").CircleWishlistMap;
+  onToggleStar?: (id: string) => void;
+  onUpdateMemo?: (id: string, memo: string) => void;
+  eventWishlist?: string[];
+  onToggleEventWishlist?: (slug: string) => void;
 };
 
 const statusChip = (active: boolean) =>
@@ -35,7 +40,8 @@ const genreChip = (active: boolean) =>
 /** 행사 하나의 체크리스트 화면. 필터/시트 상태는 하단 네비와 공유하므로 쉘이 소유하고 props로 받는다. */
 export function ChecklistScreen({
   event, circleSlug, checks, onToggle, filters, sheet, onSheet: setSheet,
-  onOpenEvent, onOpenCircle,
+  onOpenEvent, onOpenCircle, wishlist = {}, onToggleStar, onUpdateMemo,
+  eventWishlist = [], onToggleEventWishlist,
 }: Props) {
   const { status, setStatus, selectedIps, setSelectedIps, query, setQuery } = filters;
   const searchRef = useRef<HTMLInputElement>(null);
@@ -57,7 +63,6 @@ export function ChecklistScreen({
         : null;
   const loading = eventsQuery.isFetching || circlesQuery.isFetching;
 
-  // 행사장 서클 + 통판(unlisted)을 한 데이터셋으로 다뤄 검색·필터·체크를 일관 적용
   const all = useMemo(() => [...circles, ...witchformExtra], [circles, witchformExtra]);
 
   const opener = useRef<HTMLElement | null>(null);
@@ -76,21 +81,19 @@ export function ChecklistScreen({
     };
   }, [sheet]);
 
-  // 진행률은 통판 포함(모두 방문 대상) — 제품 규칙
   const doneCount = all.filter((c) => checks[c.id]).length;
+  const starCount = all.filter((c) => wishlist[c.id]?.star).length;
 
   const filtered = useMemo(
-    () => filterCircles(all, { checks, status, ips: selectedIps, query }),
-    [all, checks, status, selectedIps, query],
+    () => filterCircles(all, { checks, status, ips: selectedIps, query, wishlist }),
+    [all, checks, status, selectedIps, query, wishlist],
   );
   const boothList = filtered.filter((c) => !c.unlisted);
   const tsuhanList = filtered.filter((c) => c.unlisted);
   const detail = circleSlug ? all.find((c) => c.id === circleSlug) ?? null : null;
 
-  // 상세 패널이 열리면 xl에서도 2열 유지(목록 폭이 줄어듦)
   const gridCls = "grid gap-3 md:grid-cols-2 " + (detail ? "" : "xl:grid-cols-3");
   const visibleSheet = sheet;
-  // 모바일: 시트가 열렸을 때만 하단 패널로 노출(네비 높이만큼 위). md 이상: topbar 인라인.
   const sheetPanel = (s: Exclude<Sheet, null>) =>
     visibleSheet === s
       ? "glass fixed left-1/2 -translate-x-1/2 w-full max-w-[560px] bottom-0 z-20 rounded-t-[28px] border-b-0 px-5 pt-5 pb-[calc(92px+env(safe-area-inset-bottom))] max-h-[75vh] overflow-y-auto "
@@ -107,8 +110,11 @@ export function ChecklistScreen({
           item={c}
           checked={!!checks[c.id]}
           onToggle={() => onToggle(c.id)}
-          onOpen={() => eventSlug && onOpenCircle(eventSlug, c.id)}
-          color={badgeColor(c.id, all)}
+           onOpen={() => eventSlug && onOpenCircle(eventSlug, c.id)}
+           color={badgeColor(c.id, all)}
+           starred={wishlist[c.id]?.star}
+           memo={wishlist[c.id]?.memo}
+           onStar={onToggleStar ? () => onToggleStar(c.id) : undefined}
         />
       ))}
     </div>
@@ -116,9 +122,9 @@ export function ChecklistScreen({
 
   return (
     <div className="xl:flex xl:items-start">
-      {/* 목록 — 상세가 열리면 xl 미만은 숨김(전체 화면 상세), xl 이상은 유지 */}
+
       <div className={"min-w-0 flex-1 pb-[calc(88px+env(safe-area-inset-bottom))] md:pb-7 " /* 하단 바 64px + 오프셋 12px + 여백 12px */ + (detail ? "hidden xl:block" : "")}>
-        {/* sticky 헤더(모바일: 제목 + 진행률만) / topbar(데스크톱: 검색·필터 인라인) — fixed 시트가 자식이라 backdrop-blur 금지 */}
+
         <div className="sticky top-0 z-10 bg-bg px-5 pt-4 pb-3 border-b border-line md:px-8 md:bg-bg/95 md:backdrop-blur">
           <div className="flex items-center justify-between gap-3 md:mb-3 md:gap-6">
             <div className="min-w-0">
@@ -130,7 +136,7 @@ export function ChecklistScreen({
               </div>
             </div>
             <div className="flex shrink-0 items-center gap-2">
-              <div className="text-[12.5px] font-bold text-accent">방문 {doneCount}/{all.length}</div>
+              <div className="text-[12.5px] font-bold text-accent">찜 {starCount} · 방문 {doneCount}/{all.length}</div>
             </div>
           </div>
 
@@ -147,8 +153,8 @@ export function ChecklistScreen({
                 type="search"
                 value={query}
                 onChange={(e) => setQuery(e.target.value)}
-                placeholder="서클 · 부스 · 장르 검색"
-                aria-label="서클·부스·장르 검색"
+                placeholder="서클 · 부스 · 장르 · 메모 검색"
+                aria-label="서클·부스·장르·메모 검색"
                 className="flex-1 min-w-0 border-0 outline-none bg-transparent text-[16px] text-ink placeholder:text-faint"
               />
               {query ? (
@@ -177,7 +183,7 @@ export function ChecklistScreen({
               ))}
             </div>
 
-            {/* 장르 칩 — 모바일 시트 안에서는 줄바꿈, 데스크톱은 topbar 아래 */}
+
             <div className="flex flex-wrap gap-2 pt-3 md:pt-4 md:max-h-24 md:overflow-y-auto">
               <button onClick={() => setSelectedIps([])} aria-pressed={selectedIps.length === 0} className={genreChip(selectedIps.length === 0)}>
                 전체 장르
@@ -195,13 +201,13 @@ export function ChecklistScreen({
             </div>
           </div>
 
-          {/* 행사 전환 시트 — 항목 탭 시 닫힘(현재 행사를 다시 눌러도 hashchange가 없어 명시적으로 닫는다). md 이상은 사이드바가 담당 */}
+
           <div id="sheet-events" role="group" aria-label="행사 전환" onClick={() => setSheet(null)} className={sheetPanel("events") + "md:hidden"}>
             {sheet === "events" ? (
               <>
                 <div className="text-xs font-extrabold tracking-[0.04em] text-faint">현재 행사</div>
                 <div className="mt-1 text-[17px] font-extrabold text-ink truncate">{event?.title}</div>
-                <EventList events={events} currentSlug={eventSlug} />
+                <EventList events={events} currentSlug={eventSlug} wishlist={eventWishlist} onToggleWishlist={onToggleEventWishlist} />
               </>
             ) : null}
           </div>
@@ -209,7 +215,7 @@ export function ChecklistScreen({
 
         <div className="px-[22px] pt-3.5 pb-2 text-[12.5px] font-bold text-faint md:px-8">참가 서클 {filtered.length}곳</div>
 
-        {/* 카드 목록 — 데스크톱은 2~3열 그리드 */}
+
         <div className="px-5 md:px-8" {...(visibleSheet ? { inert: "" } : {})}>
           {loadError && (
             <div className="text-center py-14" role="alert">
@@ -228,7 +234,7 @@ export function ChecklistScreen({
           )}
           {!loadError && renderCards(boothList)}
 
-          {/* 통판(윗치폼) 섹션 — 행사장 부스 없이 온라인 주문 */}
+
           {!loadError && tsuhanList.length > 0 && (
             <>
               <div className="flex items-center gap-2 mt-7 mb-3.5">
@@ -246,7 +252,7 @@ export function ChecklistScreen({
         </div>
       </div>
 
-      {/* 서클 상세 — xl 미만은 전체 화면, xl 이상은 우측 패널(목록 유지) */}
+
       {detail && (
         <section aria-label="서클 상세" className="min-w-0 xl:w-[400px] xl:shrink-0 xl:sticky xl:top-0 xl:h-screen xl:overflow-y-auto xl:border-l xl:border-line">
           <Detail
@@ -254,8 +260,12 @@ export function ChecklistScreen({
             checked={!!checks[detail.id]}
             onToggle={() => onToggle(detail.id)}
             onBack={() => eventSlug && onOpenEvent(eventSlug)}
-            color={badgeColor(detail.id, all)}
-          />
+             color={badgeColor(detail.id, all)}
+             starred={wishlist[detail.id]?.star}
+             memo={wishlist[detail.id]?.memo}
+             onStar={onToggleStar ? () => onToggleStar(detail.id) : undefined}
+             onUpdateMemo={onUpdateMemo ? (memo) => onUpdateMemo(detail.id, memo) : undefined}
+           />
         </section>
       )}
     </div>

--- a/src/screens/EventsScreen.tsx
+++ b/src/screens/EventsScreen.tsx
@@ -2,10 +2,15 @@ import { useQuery } from "@tanstack/react-query";
 import { InstallBanner } from "../components/InstallGuide";
 import type { InstallState } from "../hooks/useInstallPrompt";
 import { eventsQuery } from "../lib/queries";
+import { eventSubtitle } from "../lib/event";
 
-export function EventsScreen({ install, onOpenSettings }: { install: InstallState; onOpenSettings: () => void }) {
+export function EventsScreen({ install, onOpenSettings, wishlist = [], onToggleWishlist }: { install: InstallState; onOpenSettings: () => void; wishlist?: string[]; onToggleWishlist?: (slug: string) => void }) {
   const { data: events = [], error, isFetching } = useQuery(eventsQuery());
   const loadError = error instanceof Error ? error.message : error ? "불러오기 실패" : null;
+  const wishlistMatches = events
+    .filter((event) => wishlist.includes(event.slug))
+    .sort((a, b) => (a.start_date ?? "").localeCompare(b.start_date ?? ""));
+
   return (
     <div className="px-5 pt-7 pb-2 md:px-8 md:py-10">
       <h1 className="text-[26px] font-extrabold text-ink">행사 선택</h1>
@@ -13,6 +18,37 @@ export function EventsScreen({ install, onOpenSettings }: { install: InstallStat
       <InstallBanner install={install} onOpenSettings={onOpenSettings} />
       {loadError ? <div role="alert" className="mt-8 text-sm text-danger">{loadError}</div> : null}
       {!isFetching && !loadError && events.length === 0 ? <div className="py-14 text-center text-sm text-faint">등록된 행사가 없어요</div> : null}
+      {!loadError && wishlistMatches.length > 0 && (
+        <section className="mt-6 md:mt-8">
+          <h2 className="mb-2 text-xs font-extrabold tracking-[0.04em] text-faint">내 위시리스트</h2>
+          <div className="flex flex-col gap-3 md:gap-1">
+            {wishlistMatches.map((candidate) => (
+              <div
+                key={`screen-wishlist-${candidate.slug}`}
+                className="block rounded-[18px] border border-line bg-card p-4 md:rounded-[10px] md:border-transparent md:px-3 md:py-2 md:bg-transparent md:hover:bg-chip"
+              >
+                <div className="flex items-center gap-1.5">
+                  <a href={`#/events/${encodeURIComponent(candidate.slug)}`} className="min-w-0 flex-1 no-underline text-[17px] font-extrabold text-ink md:text-sm">
+                    {candidate.title}
+                  </a>
+                  {onToggleWishlist && (
+                    <button
+                      type="button"
+                      onClick={() => onToggleWishlist(candidate.slug)}
+                      aria-pressed={true}
+                      aria-label={`${candidate.title} 행사 찜 해제`}
+                      className="ml-auto flex items-center justify-center w-11 h-11 md:w-8 md:h-8 rounded-xl md:rounded-lg text-lg md:text-base border border-transparent hover:border-line hover:bg-chip cursor-pointer text-amber-500 shrink-0"
+                    >
+                      ★
+                    </button>
+                  )}
+                </div>
+                <div className="mt-1 text-xs font-semibold text-faint md:mt-0.5 md:text-[11px]">{eventSubtitle(candidate)}</div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
     </div>
   );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,27 @@ export type TweetInfo = {
   ogSiteName?: string;
 };
 
+export type CircleWishlistEntry = {
+  star?: boolean;
+  memo?: string;
+};
+
+export type CircleWishlistMap = Record<string, CircleWishlistEntry>;
+
+export type EventWishlistResponse = {
+  events: string[];
+  updatedAt: string | null;
+  saved?: boolean;
+  conflict?: "stale" | "clock_skew";
+};
+
+export type CircleWishlistResponse = {
+  circles: CircleWishlistMap;
+  updatedAt: string | null;
+  saved?: boolean;
+  conflict?: "stale" | "clock_skew";
+};
+
 export type Circle = {
   id: string;
   name: string;

--- a/test/client/App.test.tsx
+++ b/test/client/App.test.tsx
@@ -232,7 +232,7 @@ describe("<App/> confirmed + unlisted", () => {
     window.location.hash = "#/events/ev";
     render(<App />);
     await screen.findByText("통판서클");
-    fireEvent.change(screen.getByPlaceholderText("서클 · 부스 · 장르 검색"), { target: { value: "통판" } });
+    fireEvent.change(screen.getByPlaceholderText("서클 · 부스 · 장르 · 메모 검색"), { target: { value: "통판" } });
     expect(screen.getByText("통판서클")).toBeTruthy();
     expect(screen.queryByText("부스서클")).toBeNull();
   });

--- a/test/client/a11y-routing.test.tsx
+++ b/test/client/a11y-routing.test.tsx
@@ -52,7 +52,7 @@ describe("<App/> accessibility + routing", () => {
     window.location.hash = "#/events/ev";
     render(<App />);
     await screen.findByText("부스서클");
-    expect(screen.getByRole("searchbox", { name: "서클·부스·장르 검색" })).toBeTruthy();
+    expect(screen.getByRole("searchbox", { name: "서클·부스·장르·메모 검색" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "행사" })).toBeTruthy();
     expect(screen.getByRole("link", { name: "전체 부스배치도 (새 창)" }).getAttribute("target")).toBe("_blank");
     const allBtn = screen.getByRole("button", { name: "전체" });

--- a/test/client/useWishlist.test.ts
+++ b/test/client/useWishlist.test.ts
@@ -1,0 +1,222 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useCircleWishlist, useEventWishlist } from "../../src/hooks/useWishlist";
+
+const json = (value: unknown) =>
+  new Response(JSON.stringify(value), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+
+// @vitest-environment jsdom
+describe("useEventWishlist", () => {
+  const validEventSlugs = ["ev1"] as const;
+
+  beforeEach(() => localStorage.clear());
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("removes deleted event slugs from local state before upload", async () => {
+    localStorage.setItem("gbc-seoko-event-wishlist", JSON.stringify({ value: ["deleted", "ev1"], updatedAt: null }));
+    const puts: unknown[] = [];
+    vi.stubGlobal("fetch", vi.fn((_url: string, init?: RequestInit) => {
+      if (init?.method === "PUT") puts.push(JSON.parse(String(init.body)));
+      return Promise.resolve(json({ events: ["deleted", "ev1"], updatedAt: null }));
+    }));
+    const { result } = renderHook(() => useEventWishlist(true, "u1", undefined, undefined, validEventSlugs));
+    expect(result.current[0]).toEqual(["ev1"]);
+    await waitFor(() => expect(puts).toHaveLength(1));
+    expect(puts[0]).toMatchObject({ events: ["ev1"] });
+  });
+
+  it("replaces deleted remote slugs instead of retrying the invalid list", async () => {
+    localStorage.setItem("gbc-seoko-event-wishlist", JSON.stringify({ value: ["ev1"], updatedAt: "2026-09-03T00:00:00.001Z" }));
+    const puts: unknown[] = [];
+    vi.stubGlobal("fetch", vi.fn((_url: string, init?: RequestInit) => {
+      if (init?.method === "PUT") puts.push(JSON.parse(String(init.body)));
+      return Promise.resolve(json({ events: ["deleted", "ev1"], updatedAt: "2026-09-03T00:00:00.000Z", saved: true }));
+    }));
+
+    const { result } = renderHook(() => useEventWishlist(true, "u1", undefined, undefined, validEventSlugs));
+
+    await waitFor(() => expect(puts).toHaveLength(1));
+    expect(result.current[0]).toEqual(["ev1"]);
+    expect(puts[0]).toMatchObject({ events: ["ev1"] });
+  });
+
+  it("does not dispatch a queued circle save after the user changes", async () => {
+    let resolveFetch!: (res: Response) => void;
+    const fetchWishlist = new Promise<Response>((resolve) => { resolveFetch = resolve; });
+    const puts: unknown[] = [];
+    vi.stubGlobal("fetch", vi.fn((_url: string, init?: RequestInit) => {
+      if (init?.method === "PUT") {
+        puts.push(JSON.parse(String(init.body)));
+        return Promise.resolve(json({ circles: {}, updatedAt: null, saved: true }));
+      }
+      return fetchWishlist;
+    }));
+
+    const { result, rerender } = renderHook(
+      (props) => useCircleWishlist(props.eventSlug, props.authenticated, props.userId),
+      { initialProps: { eventSlug: "ev1", authenticated: true, userId: "u1" } },
+    );
+    act(() => result.current.toggleStar("c1"));
+    rerender({ eventSlug: "ev1", authenticated: true, userId: "u2" });
+    resolveFetch(json({ circles: {}, updatedAt: null }));
+    await act(async () => { await fetchWishlist; });
+
+    expect(puts).toEqual([]);
+  });
+
+  it("clears anonymous wishlist before the first authenticated sync", async () => {
+    localStorage.setItem("gbc-seoko-event-wishlist", JSON.stringify({ value: ["ev1"], updatedAt: null }));
+    const puts: unknown[] = [];
+    vi.stubGlobal("fetch", vi.fn((_url: string, init?: RequestInit) => {
+      if (init?.method === "PUT") puts.push(JSON.parse(String(init.body)));
+      return Promise.resolve(json({ events: [], updatedAt: null }));
+    }));
+
+    const { result, rerender } = renderHook(
+      ({ authenticated, userId }) => useEventWishlist(authenticated, userId),
+      { initialProps: { authenticated: false, userId: null } },
+    );
+    act(() => rerender({ authenticated: true, userId: "u1" }));
+
+    await waitFor(() => expect(result.current[0]).toEqual([]));
+    expect(puts).toEqual([]);
+  });
+
+  it("cleans up storage on account switch", async () => {
+    localStorage.setItem("gbc-seoko-event-wishlist", JSON.stringify({ value: ["ev1"], updatedAt: null }));
+
+    const { rerender } = renderHook(
+      ({ user }) => useEventWishlist(true, user),
+      { initialProps: { user: "u1" } },
+    );
+
+    expect(localStorage.getItem("gbc-seoko-event-wishlist")).not.toBeNull();
+
+    rerender({ user: "u2" });
+
+    await waitFor(() => {
+      expect(localStorage.getItem("gbc-seoko-event-wishlist")).toBeNull();
+    });
+  });
+
+  it("guards against out-of-order in-flight responses overriding latest state", async () => {
+    let resolveFirst!: (res: Response) => void;
+    let resolveSecond!: (res: Response) => void;
+    const firstPut = new Promise<Response>((r) => { resolveFirst = r; });
+    const secondPut = new Promise<Response>((r) => { resolveSecond = r; });
+    const puts: any[] = [];
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string, init?: RequestInit) => {
+        if (init?.method === "PUT") {
+          puts.push(JSON.parse(String(init.body)));
+          return puts.length === 1 ? firstPut : secondPut;
+        }
+        return Promise.resolve(json({ events: [], updatedAt: null }));
+      }),
+    );
+
+    const { result } = renderHook(() => useEventWishlist(true, "u1"));
+
+    act(() => {
+      result.current[1]("ev1");
+    });
+    expect(result.current[0]).toEqual(["ev1"]);
+
+    act(() => {
+      result.current[1]("ev2");
+    });
+    expect(result.current[0]).toEqual(["ev1", "ev2"]);
+
+    await act(async () => {
+      resolveFirst(json({ events: ["ev1"], updatedAt: "2026-09-03T00:00:00.001Z", saved: true }));
+    });
+
+    await waitFor(() => expect(puts).toHaveLength(2));
+
+    await act(async () => {
+      resolveSecond(json({ events: ["ev1", "ev2"], updatedAt: "2026-09-03T00:00:00.002Z", saved: true }));
+    });
+
+    expect(result.current[0]).toEqual(["ev1", "ev2"]);
+  });
+});
+
+describe("useCircleWishlist", () => {
+  beforeEach(() => localStorage.clear());
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("toggles star immediately and flushes pending memo on unmount", async () => {
+    const puts: any[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string, init?: RequestInit) => {
+        if (init?.method === "PUT") {
+          puts.push(JSON.parse(String(init.body)));
+          return Promise.resolve(json({ circles: puts[puts.length - 1].circles, updatedAt: "2026-09-03T00:00:00.001Z", saved: true }));
+        }
+        return Promise.resolve(json({ circles: {}, updatedAt: null }));
+      }),
+    );
+
+    const { result, unmount } = renderHook(() => useCircleWishlist("ev1", true, "u1"));
+
+    act(() => {
+      result.current.toggleStar("c1");
+    });
+
+    expect(result.current.circles.c1?.star).toBe(true);
+    await waitFor(() => expect(puts.length).toBe(1));
+    expect(puts[0].circles).toEqual({ c1: { star: true } });
+
+    act(() => {
+      result.current.updateMemo("c1", "important note");
+    });
+    expect(puts.length).toBe(1);
+
+    unmount();
+
+    await waitFor(() => expect(puts.length).toBe(2));
+    expect(puts[1].circles).toEqual({ c1: { star: true, memo: "important note" } });
+  });
+
+  it("clears empty memo and removes unstarred entry", async () => {
+    const { result } = renderHook(() => useCircleWishlist("ev1", false, null));
+
+    act(() => {
+      result.current.updateMemo("c1", "first memo");
+    });
+    expect(result.current.circles.c1?.memo).toBe("first memo");
+
+    act(() => {
+      result.current.updateMemo("c1", "   ");
+    });
+    expect(result.current.circles.c1).toBeUndefined();
+  });
+
+  it.each([
+    ["logout", { eventSlug: "ev1", authenticated: true, userId: "u1" }, { eventSlug: "ev1", authenticated: false, userId: null }],
+    ["account switch", { eventSlug: "ev1", authenticated: true, userId: "u1" }, { eventSlug: "ev1", authenticated: true, userId: "u2" }],
+    ["event switch", { eventSlug: "ev1", authenticated: true, userId: "u1" }, { eventSlug: "ev2", authenticated: true, userId: "u1" }],
+  ])("does not flush a pending memo after %s", async (_change, initial, next) => {
+    const puts: unknown[] = [];
+    vi.stubGlobal("fetch", vi.fn((_url: string, init?: RequestInit) => {
+      if (init?.method === "PUT") puts.push(JSON.parse(String(init.body)));
+      return Promise.resolve(json({ circles: {}, updatedAt: null, saved: true }));
+    }));
+
+    const { result, rerender } = renderHook(
+      (props) => useCircleWishlist(props.eventSlug, props.authenticated, props.userId),
+      { initialProps: initial },
+    );
+    act(() => result.current.updateMemo("c1", "old user note"));
+    rerender(next);
+    await act(async () => { await new Promise((resolve) => setTimeout(resolve, 550)); });
+
+    expect(puts).toEqual([]);
+  });
+});

--- a/test/client/wishlist.test.ts
+++ b/test/client/wishlist.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { filterCircles } from "../../src/lib/circle";
+import {
+  clearAllWishlist,
+  compareTimestamps,
+  loadCircleWishlistState,
+  loadEventWishlistState,
+  nextWishlistTimestamp,
+  pruneCircleWishlist,
+  saveCircleWishlistState,
+  saveEventWishlistState,
+} from "../../src/lib/wishlist";
+import type { Circle } from "../../src/types";
+
+const circle = (id: string): Circle => ({ id, name: id, links: [] });
+
+describe("wishlist storage and filters", () => {
+  it("normalizes timestamps and prunes invalid circle entries", () => {
+    const storage = new Map<string, string>();
+    const kv = { getItem: (key: string) => storage.get(key) ?? null, setItem: (key: string, value: string) => storage.set(key, value) };
+    saveCircleWishlistState(kv, "ev", { value: { a: { star: true, memo: "  note  " }, b: { star: false, memo: "   " }, c: null as never }, updatedAt: "2026-09-03T00:00:00Z" });
+    expect(loadCircleWishlistState(kv, "ev")).toEqual({ value: { a: { star: true, memo: "note" } }, updatedAt: "2026-09-03T00:00:00.000Z" });
+  });
+
+  it("prunes empty memo to preserve star or completely remove entry", () => {
+    expect(pruneCircleWishlist({ a: { star: true, memo: "" }, b: { memo: "   " } })).toEqual({
+      a: { star: true },
+    });
+  });
+
+  it("handles event wishlist state and cleanup", () => {
+    const storage = new Map<string, string>();
+    const kv = {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => storage.set(key, value),
+      removeItem: (key: string) => storage.delete(key),
+      get length() { return storage.size; },
+      key: (i: number) => Array.from(storage.keys())[i] ?? null,
+    };
+    saveEventWishlistState(kv, { value: ["ev1"], updatedAt: "2026-09-03T00:00:00.000Z" });
+    expect(loadEventWishlistState(kv)).toEqual({ value: ["ev1"], updatedAt: "2026-09-03T00:00:00.000Z" });
+    saveCircleWishlistState(kv, "ev1", { value: { c1: { star: true } }, updatedAt: null });
+    expect(storage.size).toBe(2);
+
+    clearAllWishlist(kv);
+    expect(storage.size).toBe(0);
+    expect(loadEventWishlistState(kv)).toEqual({ value: [], updatedAt: null });
+  });
+
+  it("creates independent logical timestamps and compares correctly", () => {
+    const base = "2026-09-03T00:00:00.000Z";
+    expect(nextWishlistTimestamp(base, false)).toBe("2026-09-03T00:00:00.001Z");
+    expect(compareTimestamps("2026-09-03T00:00:00.000Z", "2026-09-03T00:00:00.001Z")).toBe(-1);
+    expect(compareTimestamps("2026-09-03T00:00:00.001Z", "2026-09-03T00:00:00.000Z")).toBe(1);
+    expect(compareTimestamps(null, "2026-09-03T00:00:00.000Z")).toBe(-1);
+    expect(compareTimestamps("2026-09-03T00:00:00.000Z", null)).toBe(1);
+    expect(compareTimestamps(null, null)).toBe(0);
+  });
+
+  it("filters starred circles and searches memos", () => {
+    const wishlist = { a: { star: true, memo: "고래" } };
+    expect(filterCircles([circle("a"), circle("b")], { checks: {}, status: "starred", ips: [], query: "", wishlist }).map((item) => item.id)).toEqual(["a"]);
+    expect(filterCircles([circle("a"), circle("b")], { checks: {}, status: "all", ips: [], query: "고 래", wishlist }).map((item) => item.id)).toEqual(["a"]);
+  });
+});

--- a/test/worker/migration.test.ts
+++ b/test/worker/migration.test.ts
@@ -15,6 +15,14 @@ const ipsMigration = readFileSync(
   fileURLToPath(new URL("../../migrations/0003_ips_only.sql", import.meta.url)),
   "utf8",
 );
+const wishlistMigration = readFileSync(
+  fileURLToPath(new URL("../../migrations/0006_user_wishlist.sql", import.meta.url)),
+  "utf8",
+);
+const wishlistVersionMigration = readFileSync(
+  fileURLToPath(new URL("../../migrations/0007_user_wishlist_version.sql", import.meta.url)),
+  "utf8",
+);
 
 describe("event-scoped circles migration", () => {
   it("does not create a preservation event when there are no orphan circles", () => {
@@ -141,5 +149,32 @@ describe("event-scoped circles migration", () => {
       { name: "대표 장르" },
     ]);
     expect(db.prepare("SELECT COUNT(*) AS count FROM circle_ips").get()).toMatchObject({ count: 2 });
+  });
+
+  it("applies user_wishlist migration with independent timestamps and without unused table", () => {
+    const db = new DatabaseSync(":memory:");
+    db.exec("PRAGMA foreign_keys = ON");
+    db.exec(initMigration);
+    db.exec(wishlistMigration);
+    db.exec(wishlistVersionMigration);
+
+    const tables = db.prepare("SELECT name FROM sqlite_master WHERE type='table'").all() as Array<{ name: string }>;
+    const tableNames = tables.map((t) => t.name);
+    expect(tableNames).toContain("user_wishlist");
+    expect(tableNames).not.toContain("user_wishlist_versions");
+
+    const columns = db.prepare("PRAGMA table_info(user_wishlist)").all() as Array<{ name: string; pk: number; dflt_value: unknown }>;
+    const colNames = columns.map((c) => c.name);
+    expect(colNames).toEqual(["user_id", "event_slug", "starred", "circles", "starred_at", "circles_updated_at"]);
+
+    const pkCols = columns.filter((c) => c.pk > 0).map((c) => c.name);
+    expect(pkCols).toEqual(["user_id", "event_slug"]);
+
+    db.exec("INSERT INTO user_wishlist (user_id, event_slug) VALUES ('u1', 'ev1')");
+    const row = db.prepare("SELECT * FROM user_wishlist WHERE user_id = 'u1'").get() as any;
+    expect(row.starred).toBe(0);
+    expect(row.circles).toBe("{}");
+    expect(row.starred_at).toBeNull();
+    expect(row.circles_updated_at).toBeNull();
   });
 });

--- a/test/worker/wishlist-api.test.ts
+++ b/test/worker/wishlist-api.test.ts
@@ -1,0 +1,508 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { app } from "../../worker/app";
+import { makeTestDB } from "../helpers/d1";
+
+const TOKEN = "test-token";
+
+describe("wishlist API", () => {
+  let env: any;
+  let circleIds: Record<string, number>;
+
+  beforeEach(async () => {
+    circleIds = {};
+    env = {
+      DB: makeTestDB(),
+      ADMIN_TOKEN: TOKEN,
+      AUTH_ORIGIN: "https://auth.bini59.dev",
+      AUTH_CLIENT_ID: "seoko-maps",
+      AUTH_CLIENT_SECRET: "secret",
+    };
+    await app.fetch(
+      new Request("http://x/api/events", {
+        method: "POST",
+        headers: { "content-type": "application/json", authorization: `Bearer ${TOKEN}` },
+        body: JSON.stringify({ slug: "ev1", title: "Event 1", status: "active" }),
+      }),
+      env,
+      {} as ExecutionContext,
+    );
+    await app.fetch(
+      new Request("http://x/api/events", {
+        method: "POST",
+        headers: { "content-type": "application/json", authorization: `Bearer ${TOKEN}` },
+        body: JSON.stringify({ slug: "ev2", title: "Event 2", status: "upcoming" }),
+      }),
+      env,
+      {} as ExecutionContext,
+    );
+    for (const slug of ["c1", "c2", "c3"]) {
+      await app.fetch(
+        new Request("http://x/api/circles", {
+          method: "POST",
+          headers: { "content-type": "application/json", authorization: `Bearer ${TOKEN}` },
+          body: JSON.stringify({ slug, name: slug, event_slug: "ev1" }),
+        }),
+        env,
+        {} as ExecutionContext,
+      );
+      const circle = await env.DB.prepare("SELECT id FROM circles WHERE slug = ? AND event_id = (SELECT id FROM events WHERE slug = 'ev1')").bind(slug).first<{ id: number }>();
+      circleIds[slug] = circle.id;
+    }
+  });
+
+  it("requires authentication for wishlist endpoints", async () => {
+    const getRes = await app.fetch(new Request("http://x/api/wishlist"), env, {} as ExecutionContext);
+    expect(getRes.status).toBe(401);
+
+    const putRes = await app.fetch(
+      new Request("http://x/api/wishlist", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ events: ["ev1"] }),
+      }),
+      env,
+      {} as ExecutionContext,
+    );
+    expect(putRes.status).toBe(401);
+  });
+
+  it("saves and retrieves event wishlist", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      new Response(JSON.stringify({ userId: "u1" }), { status: 200 }),
+    );
+
+    const initialGet = await app.fetch(
+      new Request("http://x/api/wishlist", { headers: { cookie: "sid=s1" } }),
+      env,
+      {} as ExecutionContext,
+    );
+    expect(initialGet.status).toBe(200);
+    expect(await initialGet.json()).toEqual({ events: [], updatedAt: null });
+
+    const putRes = await app.fetch(
+      new Request("http://x/api/wishlist", {
+        method: "PUT",
+        headers: { "content-type": "application/json", cookie: "sid=s1" },
+        body: JSON.stringify({ events: ["ev1"] }),
+      }),
+      env,
+      {} as ExecutionContext,
+    );
+    expect(putRes.status).toBe(200);
+    const putJson = await putRes.json() as any;
+    expect(putJson.saved).toBe(true);
+    expect(putJson.events).toEqual(["ev1"]);
+    expect(putJson.updatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+
+    const getRes = await app.fetch(
+      new Request("http://x/api/wishlist", { headers: { cookie: "sid=s1" } }),
+      env,
+      {} as ExecutionContext,
+    );
+    expect(await getRes.json()).toEqual({ events: ["ev1"], updatedAt: putJson.updatedAt });
+  });
+
+  it("rejects unknown event slug in event wishlist", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      new Response(JSON.stringify({ userId: "u1" }), { status: 200 }),
+    );
+
+    const putRes = await app.fetch(
+      new Request("http://x/api/wishlist", {
+        method: "PUT",
+        headers: { "content-type": "application/json", cookie: "sid=s1" },
+        body: JSON.stringify({ events: ["non-existent"] }),
+      }),
+      env,
+      {} as ExecutionContext,
+    );
+    expect(putRes.status).toBe(400);
+    const json = await putRes.json() as any;
+    expect(json.code).toBe("invalid_request");
+  });
+
+  it("returns actual server state on stale and clock skew for event wishlist", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      new Response(JSON.stringify({ userId: "u1" }), { status: 200 }),
+    );
+
+    const firstPut = await app.fetch(
+      new Request("http://x/api/wishlist", {
+        method: "PUT",
+        headers: { "content-type": "application/json", cookie: "sid=s1" },
+        body: JSON.stringify({ events: ["ev1"] }),
+      }),
+      env,
+      {} as ExecutionContext,
+    );
+    const firstJson = await firstPut.json() as any;
+
+    const stalePut = await app.fetch(
+      new Request("http://x/api/wishlist", {
+        method: "PUT",
+        headers: { "content-type": "application/json", cookie: "sid=s1" },
+        body: JSON.stringify({ events: ["ev2"], updatedAt: new Date(Date.parse(firstJson.updatedAt) - 1000).toISOString() }),
+      }),
+      env,
+      {} as ExecutionContext,
+    );
+    expect(stalePut.status).toBe(200);
+    expect(await stalePut.json()).toEqual({
+      events: ["ev1"],
+      updatedAt: firstJson.updatedAt,
+      saved: false,
+      conflict: "stale",
+    });
+
+    const skewedPut = await app.fetch(
+      new Request("http://x/api/wishlist", {
+        method: "PUT",
+        headers: { "content-type": "application/json", cookie: "sid=s1" },
+        body: JSON.stringify({ events: ["ev2"], updatedAt: "2099-01-01T00:00:00.000Z" }),
+      }),
+      env,
+      {} as ExecutionContext,
+    );
+    expect(skewedPut.status).toBe(200);
+    expect(await skewedPut.json()).toEqual({
+      events: ["ev1"],
+      updatedAt: firstJson.updatedAt,
+      saved: false,
+      conflict: "clock_skew",
+    });
+  });
+
+  it("rejects a stale replacement after a newer replacement wins its CAS", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      new Response(JSON.stringify({ userId: "u1" }), { status: 200 }),
+    );
+
+    const firstPut = await app.fetch(
+      new Request("http://x/api/wishlist", {
+        method: "PUT",
+        headers: { "content-type": "application/json", cookie: "sid=s1" },
+        body: JSON.stringify({ events: ["ev1"] }),
+      }),
+      env,
+      {} as ExecutionContext,
+    );
+    const firstJson = await firstPut.json() as any;
+    const replacementAt = new Date(Date.parse(firstJson.updatedAt) + 1000).toISOString();
+    const replacementPut = await app.fetch(
+      new Request("http://x/api/wishlist", {
+        method: "PUT",
+        headers: { "content-type": "application/json", cookie: "sid=s1" },
+        body: JSON.stringify({ events: ["ev2"], updatedAt: replacementAt }),
+      }),
+      env,
+      {} as ExecutionContext,
+    );
+    expect((await replacementPut.json() as any).saved).toBe(true);
+
+    const stalePut = await app.fetch(
+      new Request("http://x/api/wishlist", {
+        method: "PUT",
+        headers: { "content-type": "application/json", cookie: "sid=s1" },
+        body: JSON.stringify({ events: ["ev1"], updatedAt: firstJson.updatedAt }),
+      }),
+      env,
+      {} as ExecutionContext,
+    );
+    expect(await stalePut.json()).toEqual({
+      events: ["ev2"],
+      updatedAt: replacementAt,
+      saved: false,
+      conflict: "stale",
+    });
+  });
+
+  it("persists an updatedAt tombstone when the event wishlist is cleared", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      new Response(JSON.stringify({ userId: "u1" }), { status: 200 }),
+    );
+
+    const firstPut = await app.fetch(
+      new Request("http://x/api/wishlist", {
+        method: "PUT",
+        headers: { "content-type": "application/json", cookie: "sid=s1" },
+        body: JSON.stringify({ events: ["ev1"] }),
+      }),
+      env,
+      {} as ExecutionContext,
+    );
+    const firstJson = await firstPut.json() as any;
+
+    const clearPut = await app.fetch(
+      new Request("http://x/api/wishlist", {
+        method: "PUT",
+        headers: { "content-type": "application/json", cookie: "sid=s1" },
+        body: JSON.stringify({ events: [], updatedAt: new Date(Date.parse(firstJson.updatedAt) + 1000).toISOString() }),
+      }),
+      env,
+      {} as ExecutionContext,
+    );
+    const clearJson = await clearPut.json() as any;
+    expect(clearJson).toMatchObject({ events: [], saved: true });
+    expect(Date.parse(clearJson.updatedAt)).toBeGreaterThan(Date.parse(firstJson.updatedAt));
+
+    const getRes = await app.fetch(
+      new Request("http://x/api/wishlist", { headers: { cookie: "sid=s1" } }),
+      env,
+      {} as ExecutionContext,
+    );
+    expect(await getRes.json()).toEqual({ events: [], updatedAt: clearJson.updatedAt });
+  });
+
+  it("rejects a stale replacement after a newer replacement wins", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      new Response(JSON.stringify({ userId: "u1" }), { status: 200 }),
+    );
+
+    const firstPut = await app.fetch(
+      new Request("http://x/api/wishlist", {
+        method: "PUT",
+        headers: { "content-type": "application/json", cookie: "sid=s1" },
+        body: JSON.stringify({ events: ["ev1"] }),
+      }),
+      env,
+      {} as ExecutionContext,
+    );
+    const firstJson = await firstPut.json() as any;
+    const newerAt = new Date(Date.parse(firstJson.updatedAt) + 1000).toISOString();
+
+    const newerPut = await app.fetch(
+      new Request("http://x/api/wishlist", {
+        method: "PUT",
+        headers: { "content-type": "application/json", cookie: "sid=s1" },
+        body: JSON.stringify({ events: ["ev2"], updatedAt: newerAt }),
+      }),
+      env,
+      {} as ExecutionContext,
+    );
+    expect((await newerPut.json() as any).saved).toBe(true);
+
+    const stalePut = await app.fetch(
+      new Request("http://x/api/wishlist", {
+        method: "PUT",
+        headers: { "content-type": "application/json", cookie: "sid=s1" },
+        body: JSON.stringify({ events: ["ev1"], updatedAt: firstJson.updatedAt }),
+      }),
+      env,
+      {} as ExecutionContext,
+    );
+    expect(await stalePut.json()).toEqual({
+      events: ["ev2"],
+      updatedAt: newerAt,
+      saved: false,
+      conflict: "stale",
+    });
+  });
+
+  it("prunes unknown circle IDs and normalizes stored circle JSON", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      new Response(JSON.stringify({ userId: "u1" }), { status: 200 }),
+    );
+    await app.fetch(new Request("http://x/api/circles", {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${TOKEN}` },
+      body: JSON.stringify({ slug: "known", name: "Known", event_slug: "ev1" }),
+    }), env, {} as ExecutionContext);
+    const putRes = await app.fetch(new Request("http://x/api/wishlist?event=ev1", {
+      method: "PUT",
+      headers: { "content-type": "application/json", cookie: "sid=s1" },
+      body: JSON.stringify({ circles: { [String((await env.DB.prepare("SELECT id FROM circles WHERE slug = 'known'").first<{ id: number }>()).id)]: { star: true, memo: "  note  " }, deleted: { star: true } } }),
+    }), env, {} as ExecutionContext);
+const knownId = (await env.DB.prepare("SELECT id FROM circles WHERE slug = 'known'").first<{ id: number }>()).id;
+     expect(await putRes.json()).toMatchObject({ circles: { [String(knownId)]: { star: true, memo: "note" } } });
+     const row = await env.DB.prepare("SELECT circles FROM user_wishlist WHERE user_id = 'u1' AND event_slug = 'ev1'").first() as { circles: string };
+     expect(row.circles).toBe(JSON.stringify({ [String(knownId)]: { star: true, memo: "note" } }));
+  });
+
+  it("saves and retrieves circle wishlist, clearing empty memo", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      new Response(JSON.stringify({ userId: "u1" }), { status: 200 }),
+    );
+
+    const putRes = await app.fetch(
+      new Request("http://x/api/wishlist?event=ev1", {
+        method: "PUT",
+        headers: { "content-type": "application/json", cookie: "sid=s1" },
+        body: JSON.stringify({
+          circles: {
+            [String(circleIds.c1)]: { star: true, memo: "  remember this  " },
+            [String(circleIds.c2)]: { star: false, memo: "   " },
+            [String(circleIds.c3)]: { star: true, memo: "   " },
+          },
+        }),
+      }),
+      env,
+      {} as ExecutionContext,
+    );
+    expect(putRes.status).toBe(200);
+    const putJson = await putRes.json() as any;
+    expect(putJson.saved).toBe(true);
+    expect(putJson.circles).toEqual({
+      [String(circleIds.c1)]: { star: true, memo: "remember this" },
+      [String(circleIds.c3)]: { star: true },
+    });
+    expect(putJson.circles[String(circleIds.c2)]).toBeUndefined();
+
+    const getRes = await app.fetch(
+      new Request("http://x/api/wishlist?event=ev1", { headers: { cookie: "sid=s1" } }),
+      env,
+      {} as ExecutionContext,
+    );
+    expect(await getRes.json()).toEqual({
+      circles: {
+        [String(circleIds.c1)]: { star: true, memo: "remember this" },
+        [String(circleIds.c3)]: { star: true },
+      },
+      updatedAt: putJson.updatedAt,
+    });
+  });
+
+  it("returns actual server state on stale and clock skew for circle wishlist", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      new Response(JSON.stringify({ userId: "u1" }), { status: 200 }),
+    );
+
+    const firstPut = await app.fetch(
+      new Request("http://x/api/wishlist?event=ev1", {
+        method: "PUT",
+        headers: { "content-type": "application/json", cookie: "sid=s1" },
+        body: JSON.stringify({ circles: { [String(circleIds.c1)]: { star: true } } }),
+      }),
+      env,
+      {} as ExecutionContext,
+    );
+    const firstJson = await firstPut.json() as any;
+
+    const stalePut = await app.fetch(
+      new Request("http://x/api/wishlist?event=ev1", {
+        method: "PUT",
+        headers: { "content-type": "application/json", cookie: "sid=s1" },
+        body: JSON.stringify({
+          circles: { [String(circleIds.c2)]: { star: true } },
+          updatedAt: new Date(Date.parse(firstJson.updatedAt) - 1000).toISOString(),
+        }),
+      }),
+      env,
+      {} as ExecutionContext,
+    );
+    expect(stalePut.status).toBe(200);
+    expect(await stalePut.json()).toEqual({
+      circles: { [String(circleIds.c1)]: { star: true } },
+      updatedAt: firstJson.updatedAt,
+      saved: false,
+      conflict: "stale",
+    });
+
+    const skewedPut = await app.fetch(
+      new Request("http://x/api/wishlist?event=ev1", {
+        method: "PUT",
+        headers: { "content-type": "application/json", cookie: "sid=s1" },
+        body: JSON.stringify({ circles: { [String(circleIds.c2)]: { star: true } }, updatedAt: "2099-01-01T00:00:00.000Z" }),
+      }),
+      env,
+      {} as ExecutionContext,
+    );
+    expect(skewedPut.status).toBe(200);
+    expect(await skewedPut.json()).toEqual({
+      circles: { [String(circleIds.c1)]: { star: true } },
+      updatedAt: firstJson.updatedAt,
+      saved: false,
+      conflict: "clock_skew",
+    });
+  });
+
+  it("keeps event timestamps and circle timestamps completely independent", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      new Response(JSON.stringify({ userId: "u1" }), { status: 200 }),
+    );
+
+    const eventPut = await app.fetch(
+      new Request("http://x/api/wishlist", {
+        method: "PUT",
+        headers: { "content-type": "application/json", cookie: "sid=s1" },
+        body: JSON.stringify({ events: ["ev1"] }),
+      }),
+      env,
+      {} as ExecutionContext,
+    );
+    const eventJson = await eventPut.json() as any;
+    expect(eventJson.saved).toBe(true);
+
+    const circlePut = await app.fetch(
+      new Request("http://x/api/wishlist?event=ev1", {
+        method: "PUT",
+        headers: { "content-type": "application/json", cookie: "sid=s1" },
+        body: JSON.stringify({ circles: { [String(circleIds.c1)]: { star: true, memo: "test" } } }),
+      }),
+      env,
+      {} as ExecutionContext,
+    );
+    const circleJson = await circlePut.json() as any;
+    expect(circleJson.saved).toBe(true);
+
+    const eventGet = await app.fetch(
+      new Request("http://x/api/wishlist", { headers: { cookie: "sid=s1" } }),
+      env,
+      {} as ExecutionContext,
+    );
+    const eventGetJson = await eventGet.json() as any;
+    expect(eventGetJson.events).toEqual(["ev1"]);
+    expect(eventGetJson.updatedAt).toBe(eventJson.updatedAt);
+
+    const eventPut2 = await app.fetch(
+      new Request("http://x/api/wishlist", {
+        method: "PUT",
+        headers: { "content-type": "application/json", cookie: "sid=s1" },
+        body: JSON.stringify({
+          events: ["ev1", "ev2"],
+          updatedAt: new Date(Date.parse(eventJson.updatedAt) + 1000).toISOString(),
+        }),
+      }),
+      env,
+      {} as ExecutionContext,
+    );
+    const eventPut2Json = await eventPut2.json() as any;
+    expect(eventPut2Json.saved).toBe(true);
+
+    const circleGet = await app.fetch(
+      new Request("http://x/api/wishlist?event=ev1", { headers: { cookie: "sid=s1" } }),
+      env,
+      {} as ExecutionContext,
+    );
+    const circleGetJson = await circleGet.json() as any;
+    expect(circleGetJson.circles).toEqual({ [String(circleIds.c1)]: { star: true, memo: "test" } });
+    expect(circleGetJson.updatedAt).toBe(circleJson.updatedAt);
+  });
+
+  it("rejects memo exceeding 500 characters and disallowed fields", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      new Response(JSON.stringify({ userId: "u1" }), { status: 200 }),
+    );
+
+    const tooLong = await app.fetch(
+      new Request("http://x/api/wishlist?event=ev1", {
+        method: "PUT",
+        headers: { "content-type": "application/json", cookie: "sid=s1" },
+        body: JSON.stringify({ circles: { [String(circleIds.c1)]: { memo: "a".repeat(501) } } }),
+      }),
+      env,
+      {} as ExecutionContext,
+    );
+    expect(tooLong.status).toBe(400);
+
+    const badField = await app.fetch(
+      new Request("http://x/api/wishlist?event=ev1", {
+        method: "PUT",
+        headers: { "content-type": "application/json", cookie: "sid=s1" },
+        body: JSON.stringify({ circles: { [String(circleIds.c1)]: { malicious: "hack" } } }),
+      }),
+      env,
+      {} as ExecutionContext,
+    );
+    expect(badField.status).toBe(400);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,9 @@ export default defineConfig({
   test: {
     // 파일별 // @vitest-environment 주석으로 jsdom 오버라이드 (UI 테스트)
     environment: "node",
+    environmentMatchGlobs: [["test/client/**", "jsdom"]],
+    fileParallelism: false,
+    maxWorkers: 1,
     include: ["test/**/*.test.{ts,tsx}"],
   },
 });

--- a/worker/app.ts
+++ b/worker/app.ts
@@ -13,6 +13,8 @@ import {
   intId,
   optBool,
   dateOnly,
+  wishlistMap,
+  wishlistEvents,
 } from "./validate";
 import { md5Hex } from "./md5";
 
@@ -93,6 +95,7 @@ type EventStatusRow = {
 };
 
 type UserChecksRow = { checks: string; updated_at: string };
+type UserWishlistRow = { starred: number; circles: string; starred_at: string | null; circles_updated_at: string | null };
 
 const CHECKS_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
 const MAX_CLIENT_CLOCK_AHEAD_MS = 5 * 60 * 1000;
@@ -241,7 +244,7 @@ app.use("*", cors({
 }));
 
 // require bearer token for mutating routes only (session-cookie routes are exempt)
-const SESSION_ROUTES = ["/api/checks", "/api/auth/logout", "/api/feedback"];
+const SESSION_ROUTES = ["/api/checks", "/api/wishlist", "/api/auth/logout", "/api/feedback"];
 app.use("*", async (c, next) => {
   if (["POST", "PATCH", "PUT", "DELETE"].includes(c.req.method) && !SESSION_ROUTES.includes(c.req.path)) {
     const auth = c.req.header("authorization") || "";
@@ -406,6 +409,139 @@ app.put("/checks", async (c) => {
     .bind(user.userId, eventSlug)
     .first<UserChecksRow>();
   return c.json({ checks: latest ? parseStoredChecks(latest.checks) : {}, updatedAt: formatStoredChecksTimestamp(latest?.updated_at), saved: false, conflict: "stale" });
+});
+
+function parseWishlistCircles(value: string): Record<string, { star?: boolean; memo?: string }> {
+  try {
+    return wishlistMap(JSON.parse(value));
+  } catch {
+    return {};
+  }
+}
+
+app.get("/wishlist", async (c) => {
+  const user = await requireAuth(c);
+  if (user instanceof Response) return user;
+  const eventSlug = c.req.query("event");
+  if (eventSlug) {
+    vSlug(eventSlug, "event");
+    const event = await c.env.DB.prepare("SELECT slug FROM events WHERE slug = ?").bind(eventSlug).first<{ slug: string }>();
+    if (!event) return c.json({ error: "event not found", code: "not_found" }, 404);
+    const row = await c.env.DB.prepare("SELECT circles, circles_updated_at FROM user_wishlist WHERE user_id = ? AND event_slug = ?")
+      .bind(user.userId, eventSlug).first<UserWishlistRow>();
+    return c.json({ circles: row ? parseWishlistCircles(row.circles) : {}, updatedAt: formatStoredChecksTimestamp(row?.circles_updated_at) });
+  }
+  const { results } = await c.env.DB.prepare("SELECT event_slug FROM user_wishlist WHERE user_id = ? AND starred = 1 ORDER BY event_slug")
+    .bind(user.userId).all<{ event_slug: string }>();
+  const latest = await c.env.DB.prepare("SELECT updated_at FROM user_wishlist_version WHERE user_id = ?")
+    .bind(user.userId).first<{ updated_at: string | null }>();
+  if (latest) return c.json({ events: results.map((row) => row.event_slug), updatedAt: formatStoredChecksTimestamp(latest.updated_at) });
+  const fallback = await c.env.DB.prepare("SELECT MAX(starred_at) as max_at FROM user_wishlist WHERE user_id = ?")
+    .bind(user.userId).first<{ max_at: string | null }>();
+  return c.json({ events: results.map((row) => row.event_slug), updatedAt: formatStoredChecksTimestamp(fallback?.max_at) });
+});
+
+app.put("/wishlist", async (c) => {
+  if (!sessionMutationAllowed(c)) return c.json({ error: "forbidden", code: "forbidden" }, 403);
+  const user = await requireAuth(c);
+  if (user instanceof Response) return user;
+  const eventSlug = c.req.query("event");
+  const body = await readJson(c, 512 * 1024);
+  const requestedAt = body.updatedAt === undefined || body.updatedAt === null ? null : normalizeChecksTimestamp(body.updatedAt);
+  if (body.updatedAt !== undefined && body.updatedAt !== null && !requestedAt) throw new ValidationError("updatedAt은 UTC 밀리초 ISO 시각이어야 해요");
+  if (eventSlug) {
+    vSlug(eventSlug, "event");
+    const event = await c.env.DB.prepare("SELECT slug FROM events WHERE slug = ?").bind(eventSlug).first<{ slug: string }>();
+    if (!event) return c.json({ error: "event not found", code: "invalid_request" }, 400);
+    const circles = wishlistMap(body.circles);
+    const circleRows = (await c.env.DB.prepare(
+      "SELECT c.id AS circle_id FROM circles c JOIN participations p ON p.circle_id = c.id WHERE c.event_id = (SELECT id FROM events WHERE slug = ?) AND p.event_id = (SELECT id FROM events WHERE slug = ?)",
+    ).bind(eventSlug, eventSlug).all<{ circle_id: number }>()).results;
+    const validCircleIds = new Set(circleRows.map((row) => row.circle_id));
+    for (const circleId of Object.keys(circles)) if (!validCircleIds.has(Number(circleId))) delete circles[circleId];
+
+    if (requestedAt && Date.parse(requestedAt) > Date.now() + MAX_CLIENT_CLOCK_AHEAD_MS) {
+      const current = await c.env.DB.prepare("SELECT circles, circles_updated_at FROM user_wishlist WHERE user_id = ? AND event_slug = ?")
+        .bind(user.userId, eventSlug)
+        .first<UserWishlistRow>();
+      return c.json({
+        circles: current ? parseWishlistCircles(current.circles) : {},
+        updatedAt: formatStoredChecksTimestamp(current?.circles_updated_at),
+        saved: false,
+        conflict: "clock_skew",
+      });
+    }
+
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const current = await c.env.DB.prepare("SELECT circles, circles_updated_at FROM user_wishlist WHERE user_id = ? AND event_slug = ?")
+        .bind(user.userId, eventSlug).first<UserWishlistRow>();
+      const rawCurrentAt = current?.circles_updated_at ?? null;
+      const currentAt = formatStoredChecksTimestamp(rawCurrentAt);
+      if (current && currentAt && (!requestedAt || Date.parse(requestedAt) <= Date.parse(currentAt))) {
+        return c.json({ circles: parseWishlistCircles(current.circles), updatedAt: currentAt, saved: false, conflict: "stale" });
+      }
+      const savedAt = nextServerTimestamp(currentAt, requestedAt);
+      if (!current) {
+        const inserted = await c.env.DB.prepare("INSERT INTO user_wishlist (user_id, event_slug, circles, starred, circles_updated_at) VALUES (?, ?, ?, 0, ?) ON CONFLICT(user_id, event_slug) DO NOTHING")
+          .bind(user.userId, eventSlug, JSON.stringify(circles), savedAt).run();
+        if (Number((inserted.meta as { changes?: number } | undefined)?.changes ?? 0) > 0) {
+          return c.json({ circles, updatedAt: savedAt, saved: true });
+        }
+        continue;
+      }
+      if (rawCurrentAt === null) {
+        const updated = await c.env.DB.prepare("UPDATE user_wishlist SET circles = ?, circles_updated_at = ? WHERE user_id = ? AND event_slug = ? AND circles_updated_at IS NULL")
+          .bind(JSON.stringify(circles), savedAt, user.userId, eventSlug).run();
+        if (Number((updated.meta as { changes?: number } | undefined)?.changes ?? 0) > 0) {
+          return c.json({ circles, updatedAt: savedAt, saved: true });
+        }
+      } else {
+        const updated = await c.env.DB.prepare("UPDATE user_wishlist SET circles = ?, circles_updated_at = ? WHERE user_id = ? AND event_slug = ? AND circles_updated_at = ? AND circles_updated_at < ?")
+          .bind(JSON.stringify(circles), savedAt, user.userId, eventSlug, rawCurrentAt, savedAt).run();
+        if (Number((updated.meta as { changes?: number } | undefined)?.changes ?? 0) > 0) {
+          return c.json({ circles, updatedAt: savedAt, saved: true });
+        }
+      }
+    }
+    const latest = await c.env.DB.prepare("SELECT circles, circles_updated_at FROM user_wishlist WHERE user_id = ? AND event_slug = ?")
+      .bind(user.userId, eventSlug).first<UserWishlistRow>();
+    return c.json({ circles: latest ? parseWishlistCircles(latest.circles) : {}, updatedAt: formatStoredChecksTimestamp(latest?.circles_updated_at), saved: false, conflict: "stale" });
+  }
+
+  const events = wishlistEvents(body.events);
+  const knownEvents = (await c.env.DB.prepare("SELECT slug FROM events").all<{ slug: string }>()).results.map((row) => row.slug);
+  if (events.some((event) => !knownEvents.includes(event))) return c.json({ error: "event not found", code: "invalid_request" }, 400);
+
+  const currentRows = (await c.env.DB.prepare("SELECT event_slug FROM user_wishlist WHERE user_id = ? AND starred = 1 ORDER BY event_slug").bind(user.userId).all<{ event_slug: string }>()).results;
+  const currentEvents = currentRows.map((row) => row.event_slug);
+  const currentVersion = await c.env.DB.prepare("SELECT updated_at FROM user_wishlist_version WHERE user_id = ?").bind(user.userId).first<{ updated_at: string | null }>();
+  const currentAtRow = await c.env.DB.prepare("SELECT MAX(starred_at) as max_at FROM user_wishlist WHERE user_id = ?").bind(user.userId).first<{ max_at: string | null }>();
+  const currentAt = formatStoredChecksTimestamp(currentVersion?.updated_at ?? currentAtRow?.max_at);
+
+  if (requestedAt && Date.parse(requestedAt) > Date.now() + MAX_CLIENT_CLOCK_AHEAD_MS) {
+    return c.json({ events: currentEvents, updatedAt: currentAt, saved: false, conflict: "clock_skew" });
+  }
+
+  if (currentAt && (!requestedAt || Date.parse(requestedAt) <= Date.parse(currentAt))) {
+    return c.json({ events: currentEvents, updatedAt: currentAt, saved: false, conflict: "stale" });
+  }
+
+  const savedAt = nextServerTimestamp(currentAt, requestedAt);
+  const batchResults = await c.env.DB.batch([
+    c.env.DB.prepare("INSERT INTO user_wishlist_version (user_id, updated_at) VALUES (?, ?) ON CONFLICT(user_id) DO NOTHING").bind(user.userId, currentAt),
+    currentVersion || currentAt
+      ? c.env.DB.prepare("UPDATE user_wishlist_version SET updated_at = ? WHERE user_id = ? AND updated_at = ? AND updated_at < ?").bind(savedAt, user.userId, currentVersion?.updated_at ?? currentAt, savedAt)
+      : c.env.DB.prepare("UPDATE user_wishlist_version SET updated_at = ? WHERE user_id = ? AND updated_at IS NULL").bind(savedAt, user.userId),
+    c.env.DB.prepare("UPDATE user_wishlist SET starred = 0, starred_at = ? WHERE user_id = ? AND starred = 1 AND EXISTS (SELECT 1 FROM user_wishlist_version WHERE user_id = ? AND updated_at = ?)").bind(savedAt, user.userId, user.userId, savedAt),
+    ...events.map((event) => c.env.DB.prepare("INSERT INTO user_wishlist (user_id, event_slug, starred, starred_at) SELECT ?, ?, 1, ? WHERE EXISTS (SELECT 1 FROM user_wishlist_version WHERE user_id = ? AND updated_at = ?) ON CONFLICT(user_id, event_slug) DO UPDATE SET starred = 1, starred_at = excluded.starred_at").bind(user.userId, event, savedAt, user.userId, savedAt)),
+  ]);
+  const versionResult = batchResults[1] as { meta?: { changes?: number } } | undefined;
+  if (Number(versionResult?.meta?.changes ?? 0) === 0) {
+    const latestRows = (await c.env.DB.prepare("SELECT event_slug FROM user_wishlist WHERE user_id = ? AND starred = 1 ORDER BY event_slug").bind(user.userId).all<{ event_slug: string }>()).results;
+    const latestVersion = await c.env.DB.prepare("SELECT updated_at FROM user_wishlist_version WHERE user_id = ?").bind(user.userId).first<{ updated_at: string | null }>();
+    return c.json({ events: latestRows.map((row) => row.event_slug), updatedAt: formatStoredChecksTimestamp(latestVersion?.updated_at), saved: false, conflict: "stale" });
+  }
+  return c.json({ events, updatedAt: savedAt, saved: true });
 });
 
 app.get("/events", async (c) => {

--- a/worker/validate.ts
+++ b/worker/validate.ts
@@ -82,3 +82,34 @@ export function intId(v: unknown, name: string): number {
 export function optBool(v: unknown): boolean {
   return v === true || v === 1 || v === "1" || v === "true";
 }
+
+export type WishlistEntry = { star?: boolean; memo?: string };
+export type WishlistMap = Record<string, WishlistEntry>;
+
+export function wishlistMap(v: unknown, name = "circles"): WishlistMap {
+  if (!v || typeof v !== "object" || Array.isArray(v)) fail(`${name}는 JSON 객체여야 해요`);
+  const source = v as Record<string, unknown>;
+  const keys = Object.keys(source);
+  if (keys.length > 3000 || keys.some((key) => key.length === 0 || key.length > 200)) fail(`${name} 항목이 너무 많거나 길어요`);
+  const output: WishlistMap = {};
+  for (const key of keys) {
+    const value = source[key];
+    if (!value || typeof value !== "object" || Array.isArray(value)) fail(`${name}.${key}는 JSON 객체여야 해요`);
+    const entry = value as Record<string, unknown>;
+    if (Object.keys(entry).some((field) => field !== "star" && field !== "memo")) fail(`${name}.${key}에 허용되지 않은 필드가 있어요`);
+    if (entry.star !== undefined && typeof entry.star !== "boolean") fail(`${name}.${key}.star는 boolean이어야 해요`);
+    if (entry.memo !== undefined && typeof entry.memo !== "string") fail(`${name}.${key}.memo는 문자열이어야 해요`);
+    if (typeof entry.memo === "string" && entry.memo.length > 500) fail(`${name}.${key}.memo는 500자 이하이어야 해요`);
+    const memo = typeof entry.memo === "string" ? entry.memo.trim() : undefined;
+    const star = entry.star === true;
+    if (star || memo) output[key] = { ...(star ? { star: true } : {}), ...(memo ? { memo } : {}) };
+  }
+  return output;
+}
+
+export function wishlistEvents(v: unknown): string[] {
+  if (!Array.isArray(v)) fail("events는 배열이어야 해요");
+  const events = (v as unknown[]).map((item: unknown, index: number) => slug(item, `events[${index}]`));
+  if (new Set(events).size !== events.length || events.length > 3000) fail("events 항목이 너무 많거나 중복돼요");
+  return events;
+}


### PR DESCRIPTION
## Summary\n- 행사 위시리스트와 서클 찜/메모 기능 추가\n- D1 저장 및 로그인 동기화, 충돌 해결, 로컬 우선 저장 구현\n- 행사/서클 목록 UI, 필터, 검색, 접근성 및 테스트 추가\n\n## Issues\nCloses #69\nCloses #70\nCloses #71\n\n## Verification\n- npm test\n- npm run typecheck\n- npm run build