### PR TITLE
fix: 모바일 위시리스트 정보 밀도 개선

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -24,16 +24,16 @@ export function Card({
 }) {
   const short = boothShort(item);
   const cardCls = [
-    "relative rounded-[10px] p-4 bg-card border border-line transition-colors hover:border-line-strong",
+    "relative rounded-[10px] px-3.5 py-3 bg-card border border-line transition-colors hover:border-line-strong md:p-4",
     item.highlight ? "ring-[1.6px] ring-accent/40" : "",
     checked ? "bg-chip opacity-60" : "",
   ].join(" ");
 
   return (
     <div className={cardCls}>
-      <div className="flex items-start gap-[11px]">
+      <div className="flex items-start gap-2 md:gap-[11px]">
         <div
-          className="w-[34px] h-[34px] rounded-[10px] flex items-center justify-center text-white font-extrabold flex-none -tracking-[0.02em]"
+          className="w-[30px] h-[30px] rounded-[9px] flex items-center justify-center text-white font-extrabold flex-none -tracking-[0.02em] md:w-[34px] md:h-[34px] md:rounded-[10px]"
           style={{
             background: color,
             fontSize: short.length > 2 ? 11 : 15,
@@ -57,7 +57,7 @@ export function Card({
           </div>
           <div
             className={
-              "text-[16.5px] font-extrabold -tracking-[0.01em] text-ink leading-[1.28] mt-0.5 " +
+              "text-[15px] font-extrabold -tracking-[0.01em] text-ink leading-[1.28] mt-0.5 md:text-[16.5px] " +
               (checked ? "line-through decoration-[#b8bcc4]" : "")
             }
           >
@@ -74,7 +74,7 @@ export function Card({
             aria-pressed={starred}
             aria-label={`${item.name} 찜 ${starred ? "해제" : "하기"}`}
             className={
-              "flex items-center justify-center w-11 h-11 rounded-xl text-lg font-extrabold cursor-pointer transition-colors border " +
+              "flex items-center justify-center w-9 h-9 rounded-lg text-base font-extrabold cursor-pointer transition-colors border md:w-11 md:h-11 md:rounded-xl md:text-lg " +
               (starred
                 ? "text-amber-500 border-amber-500/30 bg-amber-500/10"
                 : "text-faint hover:text-muted border-line bg-card hover:bg-chip")
@@ -87,7 +87,7 @@ export function Card({
           onClick={onToggle}
           aria-label={checked ? "방문 체크 해제" : "방문 체크"}
           className={
-            "w-[26px] h-[26px] rounded-full flex items-center justify-center flex-none border-2 cursor-pointer transition-colors " +
+            "w-6 h-6 rounded-full flex items-center justify-center flex-none border-2 cursor-pointer transition-colors md:w-[26px] md:h-[26px] " +
             (checked ? "bg-accent border-accent" : "bg-transparent border-line-strong")
           }
         >

--- a/src/components/Detail.tsx
+++ b/src/components/Detail.tsx
@@ -228,7 +228,7 @@ export function Detail({
               aria-pressed={starred}
               aria-label={`${item.name} 찜 ${starred ? "해제" : "하기"}`}
               className={
-                "flex items-center justify-center w-[54px] h-[54px] rounded-2xl border text-xl font-extrabold cursor-pointer transition-colors shrink-0 " +
+                "flex items-center justify-center w-12 h-12 rounded-xl border text-lg font-extrabold cursor-pointer transition-colors shrink-0 md:w-[54px] md:h-[54px] md:rounded-2xl md:text-xl " +
                 (starred ? "text-amber-500 border-amber-500/30 bg-amber-500/10" : "text-faint hover:text-muted border-line bg-card hover:bg-chip")
               }
             >
@@ -238,7 +238,7 @@ export function Detail({
           <button
             onClick={onToggle}
             className={
-              "flex items-center justify-center gap-2 w-full h-[54px] rounded-2xl text-[15.5px] font-extrabold cursor-pointer border-0 text-white " +
+              "flex items-center justify-center gap-2 w-full h-12 rounded-xl text-[15.5px] font-extrabold cursor-pointer border-0 text-white md:h-[54px] md:rounded-2xl " +
               (checked ? "bg-accent" : "bg-ink text-bg")
             }
           >

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -18,21 +18,21 @@ export function EventList({ events, currentSlug, wishlist = [], onToggleWishlist
   return (
     <>
       {wishlistMatches.length > 0 && (
-        <section key="wishlist" className="mt-6 md:mt-5">
+        <section key="wishlist" className="mt-4 md:mt-5">
           <h2 className="mb-2 text-xs font-extrabold tracking-[0.04em] text-faint">내 위시리스트</h2>
-          <div className="flex flex-col gap-3 md:gap-1">
+          <div className="flex flex-col gap-2 md:gap-1">
             {wishlistMatches.map((candidate) => {
               const current = candidate.slug === currentSlug;
               return (
                 <div
                   key={`wishlist-${candidate.slug}`}
                   className={
-                    "block rounded-[18px] border p-4 md:rounded-[10px] md:border-transparent md:px-3 md:py-2 " +
+                    "block rounded-[14px] border px-3.5 py-3 md:rounded-[10px] md:border-transparent md:px-3 md:py-2 " +
                     (current ? "border-accent/40 bg-accent/10" : "border-line bg-card md:bg-transparent md:hover:bg-chip")
                   }
                 >
                   <div className="flex items-center gap-1.5">
-                    <a href={`#/events/${encodeURIComponent(candidate.slug)}`} aria-current={current ? "page" : undefined} className={"min-w-0 flex-1 no-underline text-[17px] font-extrabold md:text-sm " + (current ? "text-accent" : "text-ink")}>
+                    <a href={`#/events/${encodeURIComponent(candidate.slug)}`} aria-current={current ? "page" : undefined} className={"min-w-0 flex-1 no-underline text-[15px] font-extrabold md:text-sm " + (current ? "text-accent" : "text-ink")}>
                       {current ? <span aria-hidden="true">✓</span> : null}
                       {candidate.title}
                     </a>
@@ -42,13 +42,13 @@ export function EventList({ events, currentSlug, wishlist = [], onToggleWishlist
                         onClick={() => onToggleWishlist(candidate.slug)}
                         aria-pressed={true}
                         aria-label={`${candidate.title} 행사 찜 해제`}
-                        className="ml-auto flex items-center justify-center w-11 h-11 md:w-8 md:h-8 rounded-xl md:rounded-lg text-lg md:text-base border border-transparent hover:border-line hover:bg-chip cursor-pointer text-amber-500 shrink-0"
+                        className="ml-auto flex items-center justify-center w-9 h-9 md:w-8 md:h-8 rounded-lg text-base md:text-base border border-transparent hover:border-line hover:bg-chip cursor-pointer text-amber-500 shrink-0"
                       >
                         ★
                       </button>
                     )}
                   </div>
-                  <div className="mt-1 text-xs font-semibold text-faint md:mt-0.5 md:text-[11px]">{eventSubtitle(candidate)}</div>
+                  <div className="mt-0.5 text-[11px] font-semibold text-faint md:mt-0.5 md:text-[11px]">{eventSubtitle(candidate)}</div>
                 </div>
               );
             })}
@@ -57,7 +57,7 @@ export function EventList({ events, currentSlug, wishlist = [], onToggleWishlist
       )}
       {EVENT_SECTIONS.map(({ status, label }) => {
         const matches = events
-          .filter((event) => event.status === status)
+          .filter((event) => event.status === status && !wishlist.includes(event.slug))
           .sort((a, b) => {
             const comparison = (a.start_date ?? "").localeCompare(b.start_date ?? "");
             return status === "past" ? -comparison : comparison;
@@ -74,12 +74,12 @@ export function EventList({ events, currentSlug, wishlist = [], onToggleWishlist
                   <div
                     key={candidate.slug}
                     className={
-                      "block rounded-[18px] border p-4 md:rounded-[10px] md:border-transparent md:px-3 md:py-2 " +
+                      "block rounded-[14px] border px-3.5 py-3 md:rounded-[10px] md:border-transparent md:px-3 md:py-2 " +
                       (current ? "border-accent/40 bg-accent/10" : "border-line bg-card md:bg-transparent md:hover:bg-chip")
                     }
                   >
                     <div className="flex items-center gap-1.5">
-                      <a href={`#/events/${encodeURIComponent(candidate.slug)}`} aria-current={current ? "page" : undefined} className={"min-w-0 flex-1 no-underline text-[17px] font-extrabold md:text-sm " + (current ? "text-accent" : "text-ink")}>
+                      <a href={`#/events/${encodeURIComponent(candidate.slug)}`} aria-current={current ? "page" : undefined} className={"min-w-0 flex-1 no-underline text-[15px] font-extrabold md:text-sm " + (current ? "text-accent" : "text-ink")}>
                         {current ? <span aria-hidden="true">✓</span> : null}
                         {candidate.title}
                       </a>
@@ -90,7 +90,7 @@ export function EventList({ events, currentSlug, wishlist = [], onToggleWishlist
                           aria-pressed={isStarred}
                           aria-label={`${candidate.title} 행사 찜 ${isStarred ? "해제" : "하기"}`}
                           className={
-                            "ml-auto flex items-center justify-center w-11 h-11 md:w-8 md:h-8 rounded-xl md:rounded-lg text-lg md:text-base border border-transparent hover:border-line hover:bg-chip cursor-pointer shrink-0 " +
+                            "ml-auto flex items-center justify-center w-9 h-9 md:w-8 md:h-8 rounded-lg text-base md:text-base border border-transparent hover:border-line hover:bg-chip cursor-pointer shrink-0 " +
                             (isStarred ? "text-amber-500" : "text-faint hover:text-muted")
                           }
                         >
@@ -98,7 +98,7 @@ export function EventList({ events, currentSlug, wishlist = [], onToggleWishlist
                         </button>
                       )}
                     </div>
-                    <div className="mt-1 text-xs font-semibold text-faint md:mt-0.5 md:text-[11px]">{eventSubtitle(candidate)}</div>
+                    <div className="mt-0.5 text-[11px] font-semibold text-faint md:mt-0.5 md:text-[11px]">{eventSubtitle(candidate)}</div>
                   </div>
                 );
               })}

--- a/src/screens/ChecklistScreen.tsx
+++ b/src/screens/ChecklistScreen.tsx
@@ -96,7 +96,7 @@ export function ChecklistScreen({
   const visibleSheet = sheet;
   const sheetPanel = (s: Exclude<Sheet, null>) =>
     visibleSheet === s
-      ? "glass fixed left-1/2 -translate-x-1/2 w-full max-w-[560px] bottom-0 z-20 rounded-t-[28px] border-b-0 px-5 pt-5 pb-[calc(92px+env(safe-area-inset-bottom))] max-h-[75vh] overflow-y-auto "
+      ? "glass fixed left-1/2 -translate-x-1/2 w-full max-w-[560px] bottom-0 z-20 rounded-t-[24px] border-b-0 px-5 pt-4 pb-[calc(76px+env(safe-area-inset-bottom))] max-h-[68vh] overflow-y-auto "
       : "hidden ";
   const sheetCls = (s: Exclude<Sheet, null>) =>
     sheetPanel(s) + "md:static md:block md:translate-x-0 md:max-w-none md:rounded-none md:border-0 md:bg-transparent md:shadow-none md:backdrop-filter-none md:after:hidden md:p-0 md:max-h-none md:overflow-visible";
@@ -143,7 +143,7 @@ export function ChecklistScreen({
           {visibleSheet ? <button type="button" aria-label="시트 닫기" onClick={() => setSheet(null)} className="fixed inset-0 z-20 bg-black/40 md:hidden" /> : null}
 
           <div id="sheet-search" role="group" aria-label="검색" className={sheetCls("search")}>
-            <div className="flex items-center gap-2.5 h-12 bg-card border border-line rounded-[14px] px-3.5 md:h-10 md:max-w-[520px]">
+            <div className="flex items-center gap-2.5 h-11 bg-card border border-line rounded-[14px] px-3.5 md:h-10 md:max-w-[520px]">
               <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="#9aa0aa" strokeWidth="2" strokeLinecap="round">
                 <circle cx="11" cy="11" r="7" />
                 <path d="M21 21l-4-4" />

--- a/src/screens/EventsScreen.tsx
+++ b/src/screens/EventsScreen.tsx
@@ -19,16 +19,16 @@ export function EventsScreen({ install, onOpenSettings, wishlist = [], onToggleW
       {loadError ? <div role="alert" className="mt-8 text-sm text-danger">{loadError}</div> : null}
       {!isFetching && !loadError && events.length === 0 ? <div className="py-14 text-center text-sm text-faint">등록된 행사가 없어요</div> : null}
       {!loadError && wishlistMatches.length > 0 && (
-        <section className="mt-6 md:mt-8">
+        <section className="mt-5 md:mt-8">
           <h2 className="mb-2 text-xs font-extrabold tracking-[0.04em] text-faint">내 위시리스트</h2>
-          <div className="flex flex-col gap-3 md:gap-1">
+          <div className="flex flex-col gap-2 md:gap-1">
             {wishlistMatches.map((candidate) => (
               <div
                 key={`screen-wishlist-${candidate.slug}`}
-                className="block rounded-[18px] border border-line bg-card p-4 md:rounded-[10px] md:border-transparent md:px-3 md:py-2 md:bg-transparent md:hover:bg-chip"
+                className="block rounded-[14px] border border-line bg-card px-3.5 py-3 md:rounded-[10px] md:border-transparent md:px-3 md:py-2 md:bg-transparent md:hover:bg-chip"
               >
                 <div className="flex items-center gap-1.5">
-                  <a href={`#/events/${encodeURIComponent(candidate.slug)}`} className="min-w-0 flex-1 no-underline text-[17px] font-extrabold text-ink md:text-sm">
+                  <a href={`#/events/${encodeURIComponent(candidate.slug)}`} className="min-w-0 flex-1 no-underline text-[15px] font-extrabold text-ink md:text-sm">
                     {candidate.title}
                   </a>
                   {onToggleWishlist && (
@@ -37,13 +37,13 @@ export function EventsScreen({ install, onOpenSettings, wishlist = [], onToggleW
                       onClick={() => onToggleWishlist(candidate.slug)}
                       aria-pressed={true}
                       aria-label={`${candidate.title} 행사 찜 해제`}
-                      className="ml-auto flex items-center justify-center w-11 h-11 md:w-8 md:h-8 rounded-xl md:rounded-lg text-lg md:text-base border border-transparent hover:border-line hover:bg-chip cursor-pointer text-amber-500 shrink-0"
+                      className="ml-auto flex items-center justify-center w-9 h-9 md:w-8 md:h-8 rounded-lg text-base md:text-base border border-transparent hover:border-line hover:bg-chip cursor-pointer text-amber-500 shrink-0"
                     >
                       ★
                     </button>
                   )}
                 </div>
-                <div className="mt-1 text-xs font-semibold text-faint md:mt-0.5 md:text-[11px]">{eventSubtitle(candidate)}</div>
+                <div className="mt-0.5 text-[11px] font-semibold text-faint md:mt-0.5 md:text-[11px]">{eventSubtitle(candidate)}</div>
               </div>
             ))}
           </div>


### PR DESCRIPTION
## 변경 사항\n- 모바일 행사/위시리스트 카드의 패딩, 간격, 제목, 찜 버튼 크기를 축소했습니다.\n- 행사 목록에서 위시리스트 항목이 상태별 목록에 중복 노출되지 않도록 했습니다.\n- 모바일 체크리스트 카드와 상세 하단 조작 영역을 컴팩트하게 조정했습니다.\n- 모바일 검색/필터 시트의 높이와 하단 여백을 줄였습니다.\n\nCloses #73\n\n## 검증\n- npm run typecheck 통과\n- git diff --check 통과\n- npm test: Node v18에서 NODE_OPTIONS=--experimental-sqlite 오류\n- npm run build: Node v18에서 @cloudflare/vite-plugin의 registerHooks 호환성 오류