### PR TITLE
feat: 검색·필터 통합 및 찜목록 메뉴 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { BottomNav, type Sheet } from "./components/BottomNav";
 import { ChecklistScreen } from "./screens/ChecklistScreen";
 import { EventsScreen } from "./screens/EventsScreen";
 import { SettingsScreen } from "./screens/SettingsScreen";
+import { WishlistScreen } from "./screens/WishlistScreen";
 import { clearAllChecks } from "./lib/checks";
 import { clearAllWishlist } from "./lib/wishlist";
 import { useEventWishlist, useCircleWishlist } from "./hooks/useWishlist";
@@ -20,7 +21,7 @@ import { authQuery, circlesQuery as circlesOptions, eventsQuery as eventsOptions
 const EMPTY_EVENTS: never[] = [];
 
 export default function App() {
-  const { route, openEvents, openEvent, openCircle, openSettings } = useAppRoute();
+  const { route, openEvents, openWishlist, openEvent, openCircle, openSettings } = useAppRoute();
   const queryClient = useQueryClient();
   const auth = useQuery(authQuery());
   const { enabled: authEnabled, user } = auth.data ?? SIGNED_OUT;
@@ -113,6 +114,7 @@ export default function App() {
   const visibleSheet = route.kind === "event" ? sheet : null;
   const navContext = route.kind === "settings" ? "settings" : route.kind === "events" ? "events" : "event";
   const showNav = route.kind !== "circle" && route.kind !== "legacy-circle";
+  const wishlistNav = route.kind === "wishlist";
 
   return (
     // 쉘: 모바일은 단일 컬럼(560px), md 이상은 사이드바 + 콘텐츠 2컬럼. 컴포넌트는 공유하고 레이아웃만 분기.
@@ -123,6 +125,8 @@ export default function App() {
       <Sidebar
         currentSlug={requestedEventSlug !== null ? eventSlug : null}
         showOnMobile={route.kind === "events"}
+        wishlistActive={route.kind === "wishlist"}
+        onWishlist={openWishlist}
         settingsActive={route.kind === "settings"}
         wishlist={eventWishlist}
         onToggleWishlist={handleToggleEventWishlist}
@@ -131,6 +135,8 @@ export default function App() {
       <main className={"w-full max-w-[560px] mx-auto border-x border-line md:max-w-none md:mx-0 md:border-x-0 md:min-h-screen " + (route.kind === "events" ? "" : "flex-1")}>
         {route.kind === "settings" ? (
           <SettingsScreen authEnabled={authEnabled} user={user} syncedAt={syncedAt} theme={theme} onTheme={setTheme} onLogout={handleLogout} install={install} />
+        ) : route.kind === "wishlist" ? (
+           <WishlistScreen events={events} eventWishlist={eventWishlist} />
         ) : route.kind === "events" ? (
           <EventsScreen install={install} onOpenSettings={openSettings} wishlist={eventWishlist} onToggleWishlist={handleToggleEventWishlist} />
         ) : (
@@ -153,7 +159,7 @@ export default function App() {
         )}
       </main>
       {showNav && (
-        <BottomNav context={navContext} sheet={visibleSheet} onSheet={handleNavSheet} onList={handleNavList} onEvents={openEvents} searchCount={filters.query ? 1 : 0} filterCount={filters.filterCount} onSettings={openSettings} />
+        <BottomNav context={navContext} sheet={visibleSheet} onSheet={handleNavSheet} onList={handleNavList} onEvents={openEvents} onWishlist={openWishlist} wishlistActive={wishlistNav} searchCount={filters.query ? 1 : 0} filterCount={filters.filterCount} onSettings={openSettings} />
       )}
     </div>
   );

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -4,6 +4,7 @@ const ICONS = {
   list: <><path d="M4 6h16M4 12h16M4 18h16" /></>,
   search: <><circle cx="11" cy="11" r="7" /><path d="M21 21l-4-4" /></>,
   filter: <><path d="M4 7h16M7 12h10M10 17h4" /></>,
+  wishlist: <><path d="M20.8 8.9c0 5.5-8.8 10.1-8.8 10.1S3.2 14.4 3.2 8.9A4.7 4.7 0 0 1 12 6.3a4.7 4.7 0 0 1 8.8 2.6Z" /></>,
   events: <><rect x="3" y="5" width="18" height="16" rx="2" /><path d="M3 10h18M8 3v4M16 3v4" /></>,
   settings: <><circle cx="12" cy="12" r="3" /><path d="M19.4 15a1.7 1.7 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.7 1.7 0 0 0-1.8-.3 1.7 1.7 0 0 0-1 1.5V21a2 2 0 1 1-4 0v-.1a1.7 1.7 0 0 0-1.1-1.5 1.7 1.7 0 0 0-1.8.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.7 1.7 0 0 0 .3-1.8 1.7 1.7 0 0 0-1.5-1H3a2 2 0 1 1 0-4h.1a1.7 1.7 0 0 0 1.5-1.1 1.7 1.7 0 0 0-.3-1.8l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.7 1.7 0 0 0 1.8.3H9a1.7 1.7 0 0 0 1-1.5V3a2 2 0 1 1 4 0v.1a1.7 1.7 0 0 0 1 1.5 1.7 1.7 0 0 0 1.8-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.7 1.7 0 0 0-.3 1.8V9a1.7 1.7 0 0 0 1.5 1H21a2 2 0 1 1 0 4h-.1a1.7 1.7 0 0 0-1.5 1z" /></>,
 };
@@ -53,20 +54,22 @@ function Tab({
 
 /** 모바일 전용 하단 네비 — md 이상은 사이드바/topbar가 대신한다. */
 export function BottomNav({
-  context, sheet, onSheet, onList, onEvents, searchCount, filterCount, onSettings,
+  context, sheet, onSheet, onList, onEvents, onWishlist, wishlistActive, searchCount, filterCount, onSettings,
 }: {
   context: "event" | "events" | "settings";
   sheet: Sheet;
   onSheet: (next: Sheet) => void;
   onList: () => void;
   onEvents: () => void;
+  onWishlist: () => void;
+  wishlistActive: boolean;
   searchCount: number;
   filterCount: number;
   onSettings: () => void;
 }) {
   const settingsActive = context === "settings";
   const toggle = (s: Exclude<Sheet, null>) => onSheet(sheet === s ? null : s);
-  const activeIndex = settingsActive ? 4 : context === "events" ? 3 : sheet === "search" ? 1 : sheet === "filter" ? 2 : sheet === "events" ? 3 : 0;
+  const activeIndex = settingsActive ? 5 : wishlistActive ? 3 : context === "events" ? 4 : sheet === "search" ? 1 : sheet === "filter" ? 2 : sheet === "events" ? 4 : 0;
   const listActive = activeIndex === 0;
   const sheetsDisabled = context === "events";
   const listDisabled = context === "events";
@@ -75,14 +78,15 @@ export function BottomNav({
       {/* 렌즈 인디케이터 — 탭 사이를 액체처럼 미끄러진다. */}
       <span
         aria-hidden="true"
-        className="glass-lens absolute inset-y-1.5 left-1.5 w-[calc(20%-3px)]"
+        className="glass-lens absolute inset-y-1.5 left-1.5 w-[calc(16.6667%-2.5px)]"
         style={{ transform: `translateX(${activeIndex * 100}%)` }}
       >
         <span key={activeIndex} className="glass-lens-body block h-full w-full rounded-full" />
       </span>
-      <Tab icon="list" label="목록" active={listActive} aria-current={listActive ? "page" : undefined} aria-disabled={listDisabled || undefined} disabled={listDisabled} onClick={onList} />
+      <Tab icon="list" label="목록" active={listActive && !wishlistActive} aria-current={listActive && !wishlistActive ? "page" : undefined} aria-disabled={listDisabled || undefined} disabled={listDisabled} onClick={onList} />
       <Tab icon="search" label="검색" active={sheet === "search"} badge={searchCount} aria-current={sheet === "search" ? "page" : undefined} aria-expanded={sheetsDisabled ? undefined : sheet === "search"} aria-controls={sheetsDisabled ? undefined : "sheet-search"} aria-disabled={sheetsDisabled || undefined} disabled={sheetsDisabled} onClick={() => { if (!sheetsDisabled) toggle("search"); }} />
       <Tab icon="filter" label="필터" active={sheet === "filter"} badge={filterCount} aria-current={sheet === "filter" ? "page" : undefined} aria-expanded={sheetsDisabled ? undefined : sheet === "filter"} aria-controls={sheetsDisabled ? undefined : "sheet-filter"} aria-disabled={sheetsDisabled || undefined} disabled={sheetsDisabled} onClick={() => { if (!sheetsDisabled) toggle("filter"); }} />
+      <Tab icon="wishlist" label="찜목록" active={wishlistActive} aria-current={wishlistActive ? "page" : undefined} onClick={onWishlist} />
       <Tab icon="events" label="행사" active={sheet === "events" || context === "events"} aria-current={sheet === "events" || context === "events" ? "page" : undefined} aria-expanded={context === "settings" ? undefined : sheet === "events"} aria-controls={context === "settings" ? undefined : "sheet-events"} onClick={() => { if (context === "settings") onEvents(); else if (context !== "events") toggle("events"); }} />
       <Tab icon="settings" label="설정" active={settingsActive} aria-current={settingsActive ? "page" : undefined} onClick={onSettings} />
     </nav>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { eventsQuery } from "../lib/queries";
 import type { ApiEvent } from "../api";
+import { eventHash } from "../lib/route";
 import { eventSubtitle } from "../lib/event";
 
 const EVENT_SECTIONS = [
@@ -19,7 +20,7 @@ export function EventList({ events, currentSlug, wishlist = [], onToggleWishlist
     <>
       {wishlistMatches.length > 0 && (
         <section key="wishlist" className="mt-4 md:mt-5">
-          <h2 className="mb-2 text-xs font-extrabold tracking-[0.04em] text-faint">내 위시리스트</h2>
+          <h2 className="mb-2 text-xs font-extrabold tracking-[0.04em] text-faint">찜한 행사</h2>
           <div className="flex flex-col gap-2 md:gap-1">
             {wishlistMatches.map((candidate) => {
               const current = candidate.slug === currentSlug;
@@ -32,7 +33,7 @@ export function EventList({ events, currentSlug, wishlist = [], onToggleWishlist
                   }
                 >
                   <div className="flex items-center gap-1.5">
-                    <a href={`#/events/${encodeURIComponent(candidate.slug)}`} aria-current={current ? "page" : undefined} className={"min-w-0 flex-1 no-underline text-[15px] font-extrabold md:text-sm " + (current ? "text-accent" : "text-ink")}>
+                    <a href={eventHash(candidate.slug)} aria-current={current ? "page" : undefined} className={"min-w-0 flex-1 no-underline text-[15px] font-extrabold md:text-sm " + (current ? "text-accent" : "text-ink")}>
                       {current ? <span aria-hidden="true">✓</span> : null}
                       {candidate.title}
                     </a>
@@ -79,7 +80,7 @@ export function EventList({ events, currentSlug, wishlist = [], onToggleWishlist
                     }
                   >
                     <div className="flex items-center gap-1.5">
-                      <a href={`#/events/${encodeURIComponent(candidate.slug)}`} aria-current={current ? "page" : undefined} className={"min-w-0 flex-1 no-underline text-[15px] font-extrabold md:text-sm " + (current ? "text-accent" : "text-ink")}>
+                      <a href={eventHash(candidate.slug)} aria-current={current ? "page" : undefined} className={"min-w-0 flex-1 no-underline text-[15px] font-extrabold md:text-sm " + (current ? "text-accent" : "text-ink")}>
                         {current ? <span aria-hidden="true">✓</span> : null}
                         {candidate.title}
                       </a>
@@ -120,6 +121,8 @@ export function Sidebar({
   onToggleWishlist,
   showOnMobile,
   settingsActive,
+  wishlistActive,
+  onWishlist,
   onSettings,
 }: {
   currentSlug: string | null;
@@ -127,6 +130,8 @@ export function Sidebar({
   onToggleWishlist?: (slug: string) => void;
   showOnMobile: boolean;
   settingsActive: boolean;
+  wishlistActive: boolean;
+  onWishlist: () => void;
   onSettings: () => void;
 }) {
   const { data: events = [] } = useQuery(eventsQuery());
@@ -141,6 +146,11 @@ export function Sidebar({
         <a href="#/" className="text-sm font-extrabold text-accent no-underline">걸즈밴드 체크리스트</a>
       </div>
       <nav aria-label="행사" className="flex-1 px-5 pb-6">
+        <a href="#/wishlist" onClick={(e) => { e.preventDefault(); onWishlist(); }} aria-current={wishlistActive ? "page" : undefined} className={(wishlistActive ? "bg-accent/10 text-accent " : "text-muted ") + "mt-5 flex items-center gap-2 rounded-[10px] px-3 py-2.5 text-sm font-extrabold no-underline hover:bg-chip hover:text-ink"}>
+          <span aria-hidden="true">★</span>
+          찜목록
+          {wishlist.length > 0 ? <span className="ml-auto text-xs font-bold">{wishlist.length}</span> : null}
+        </a>
         <EventList events={events} currentSlug={currentSlug} wishlist={wishlist} onToggleWishlist={onToggleWishlist} />
       </nav>
       <div className={(showOnMobile ? "hidden md:block " : "") + "border-t border-line px-5 py-4"}>

--- a/src/hooks/useAppRoute.ts
+++ b/src/hooks/useAppRoute.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { circleHash, eventHash, eventsHash, parseRoute, settingsHash, type AppRoute } from "../lib/route";
+import { circleHash, eventHash, eventsHash, parseRoute, settingsHash, wishlistHash, type AppRoute } from "../lib/route";
 
 export function useAppRoute() {
   const [route, setRoute] = useState<AppRoute>(() => parseRoute(window.location.hash));
@@ -23,6 +23,7 @@ export function useAppRoute() {
   return {
     route,
     openEvents: () => navigate(eventsHash()),
+    openWishlist: () => navigate(wishlistHash()),
     openEvent,
     openCircle: (eventSlug: string, circleSlug: string) => navigate(circleHash(eventSlug, circleSlug)),
     backToEvent: openEvent,

--- a/src/lib/route.ts
+++ b/src/lib/route.ts
@@ -3,6 +3,7 @@
 
 export type AppRoute =
   | { kind: "events" }
+  | { kind: "wishlist" }
   | { kind: "settings" }
   | { kind: "event"; eventSlug: string }
   | { kind: "circle"; eventSlug: string; circleSlug: string }
@@ -18,6 +19,7 @@ function decodeSegment(segment: string): string | null {
 
 /** location.hash → 현재 앱 화면. */
 export function parseRoute(hash: string): AppRoute {
+  if (/^#?\/wishlist$/.test(hash)) return { kind: "wishlist" };
   if (/^#?\/settings$/.test(hash)) return { kind: "settings" };
   const circle = /^#?\/events\/([^/]+)\/c\/([^/]+)$/.exec(hash);
   if (circle) {
@@ -43,6 +45,8 @@ export function parseRoute(hash: string): AppRoute {
 export const eventsHash = () => "#/";
 
 export const settingsHash = () => "#/settings";
+
+export const wishlistHash = () => "#/wishlist";
 
 export const eventHash = (eventSlug: string) =>
   `#/events/${encodeURIComponent(eventSlug)}`;

--- a/src/screens/WishlistScreen.tsx
+++ b/src/screens/WishlistScreen.tsx
@@ -1,0 +1,38 @@
+import { useMemo, useState } from "react";
+import { useQueries } from "@tanstack/react-query";
+import type { ApiEvent } from "../api";
+import { circlesQuery } from "../lib/queries";
+import { eventHash, circleHash } from "../lib/route";
+import { loadCircleWishlistState } from "../lib/wishlist";
+import type { Circle } from "../types";
+
+export function WishlistScreen({ events, eventWishlist }: { events: ApiEvent[]; eventWishlist: string[] }) {
+  const [query, setQuery] = useState("");
+  const likedEvents = useMemo(() => events.filter((event) => eventWishlist.includes(event.slug)), [events, eventWishlist]);
+  const circleQueries = useQueries({ queries: events.map((event) => circlesQuery(event.slug)) });
+  const likedCircles = useMemo(() => events.flatMap((event, index) => {
+    const data = circleQueries[index]?.data;
+    if (!data) return [];
+    const saved = loadCircleWishlistState(localStorage, event.slug).value;
+    return [...data.circles, ...data.witchformExtra].filter((circle) => saved[circle.id]?.star).map((circle) => ({ event, circle }));
+  }), [events, circleQueries]);
+  const normalized = query.trim().toLocaleLowerCase();
+  const filteredEvents = likedEvents.filter((event) => [event.title, event.alias, event.venue, event.date_label].some((value) => value?.toLocaleLowerCase().includes(normalized)));
+  const filteredCircles = likedCircles.filter(({ event, circle }) => [event.title, circle.name, circle.booth, ...(circle.ips ?? [])].some((value) => value?.toLocaleLowerCase().includes(normalized)));
+  const hasItems = likedEvents.length > 0 || likedCircles.length > 0;
+
+  return (
+    <div className="px-5 pt-7 pb-[calc(88px+env(safe-area-inset-bottom))] md:px-8 md:py-10">
+      <h1 className="text-[26px] font-extrabold text-ink">찜목록</h1>
+      <p className="mt-2 text-sm text-muted">찜한 행사와 서클을 한 곳에서 확인하세요.</p>
+      <label className="mt-6 flex h-11 items-center gap-2.5 rounded-[14px] border border-line bg-card px-3.5">
+        <span aria-hidden="true">⌕</span>
+        <input type="search" value={query} onChange={(event) => setQuery(event.target.value)} aria-label="찜목록 검색" placeholder="행사 · 서클 · 부스 검색" className="min-w-0 flex-1 bg-transparent text-[16px] text-ink outline-none" />
+      </label>
+      {!hasItems ? <div className="py-14 text-center text-sm text-faint">찜한 항목이 없어요</div> : null}
+      {hasItems && filteredEvents.length === 0 && filteredCircles.length === 0 ? <div className="py-14 text-center text-sm text-faint">검색 결과가 없어요</div> : null}
+      {filteredEvents.length > 0 ? <section className="mt-7"><h2 className="mb-2 text-xs font-extrabold tracking-[0.04em] text-faint">행사</h2><div className="flex flex-col gap-2">{filteredEvents.map((event) => <a key={event.slug} href={eventHash(event.slug)} className="rounded-[14px] border border-line bg-card px-4 py-3 no-underline hover:bg-chip"><div className="font-extrabold text-ink">{event.title}</div><div className="mt-1 text-xs font-semibold text-faint">{event.date_label ?? event.venue ?? ""}</div></a>)}</div></section> : null}
+      {filteredCircles.length > 0 ? <section className="mt-7"><h2 className="mb-2 text-xs font-extrabold tracking-[0.04em] text-faint">서클</h2><div className="flex flex-col gap-2">{filteredCircles.map(({ event, circle }) => <a key={`${event.slug}-${circle.id}`} href={circleHash(event.slug, circle.id)} className="rounded-[14px] border border-line bg-card px-4 py-3 no-underline hover:bg-chip"><div className="font-extrabold text-ink">{circle.name}</div><div className="mt-1 text-xs font-semibold text-faint">{event.title}{circle.booth ? ` · ${circle.booth}` : ""}</div></a>)}</div></section> : null}
+    </div>
+  );
+}

--- a/test/client/App.test.tsx
+++ b/test/client/App.test.tsx
@@ -507,11 +507,11 @@ describe("<App/> bottom navigation (mobile)", () => {
     vi.unstubAllGlobals();
   });
 
-  it("renders 4 tabs and opens the 행사 sheet without hiding the nav", async () => {
+  it("renders 6 tabs and opens the 행사 sheet without hiding the nav", async () => {
     render(<App />);
     await screen.findByText("부스서클");
     const nav = screen.getByRole("navigation", { name: "하단 메뉴" });
-    expect(nav.querySelectorAll("button").length).toBe(5);
+    expect(nav.querySelectorAll("button").length).toBe(6);
     expect(screen.getByRole("button", { name: "목록" }).getAttribute("aria-current")).toBe("page");
     const indicator = nav.querySelector<HTMLElement>('span[aria-hidden="true"]')!;
     expect(indicator.style.transform).toBe("translateX(0%)");
@@ -520,7 +520,7 @@ describe("<App/> bottom navigation (mobile)", () => {
 
     const eventsTab = screen.getByRole("button", { name: "행사" });
     fireEvent.click(eventsTab);
-    expect(indicator.style.transform).toBe("translateX(300%)");
+    expect(indicator.style.transform).toBe("translateX(400%)");
     expect(eventsTab.getAttribute("aria-expanded")).toBe("true");
     expect(eventsTab.getAttribute("aria-controls")).toBe("sheet-events");
     const sheet = document.getElementById("sheet-events")!;

--- a/test/client/route.test.ts
+++ b/test/client/route.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { circleHash, eventHash, eventsHash, parseRoute, settingsHash } from "../../src/lib/route";
+import { circleHash, eventHash, eventsHash, parseRoute, settingsHash, wishlistHash } from "../../src/lib/route";
 
 describe("parseRoute", () => {
   it("represents the root hash as the 행사 목록", () => {
@@ -14,6 +14,11 @@ describe("parseRoute", () => {
       eventSlug: "illustar-fes-9",
     });
     expect(eventHash("illustar-fes-9")).toBe("#/events/illustar-fes-9");
+  });
+
+  it("parses the wishlist page hash", () => {
+    expect(parseRoute("#/wishlist")).toEqual({ kind: "wishlist" });
+    expect(wishlistHash()).toBe("#/wishlist");
   });
 
   it("parses the standalone settings page hash", () => {


### PR DESCRIPTION
## 변경 사항\n- 데스크톱 사이드바와 모바일 하단 네비에  메뉴 추가\n- 행사·서클 찜 항목을 한 화면에서 검색할 수 있는 찜목록 화면 추가\n- 찜목록 라우트와 접근성 활성 상태 연결\n\nCloses #75\n\n## 검증\n- npm run typecheck\n- npx vitest run test/client/route.test.ts test/client/circle.test.ts test/client/wishlist.test.ts\n- 전체 App 테스트는 현재 Node/jsdom 의존성 호환 오류로 실행되지 않음