### PR TITLE
feat: 검색과 필터 내비게이션 메뉴 통합

### DIFF
--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -1,4 +1,4 @@
-export type Sheet = "search" | "filter" | "events" | null;
+export type Sheet = "search-filter" | "events" | null;
 
 const ICONS = {
   list: <><path d="M4 6h16M4 12h16M4 18h16" /></>,
@@ -69,7 +69,7 @@ export function BottomNav({
 }) {
   const settingsActive = context === "settings";
   const toggle = (s: Exclude<Sheet, null>) => onSheet(sheet === s ? null : s);
-  const activeIndex = settingsActive ? 5 : wishlistActive ? 3 : context === "events" ? 4 : sheet === "search" ? 1 : sheet === "filter" ? 2 : sheet === "events" ? 4 : 0;
+  const activeIndex = settingsActive ? 5 : wishlistActive ? 3 : context === "events" ? 4 : sheet === "search-filter" ? 1 : sheet === "events" ? 4 : 0;
   const listActive = activeIndex === 0;
   const sheetsDisabled = context === "events";
   const listDisabled = context === "events";
@@ -84,8 +84,7 @@ export function BottomNav({
         <span key={activeIndex} className="glass-lens-body block h-full w-full rounded-full" />
       </span>
       <Tab icon="list" label="목록" active={listActive && !wishlistActive} aria-current={listActive && !wishlistActive ? "page" : undefined} aria-disabled={listDisabled || undefined} disabled={listDisabled} onClick={onList} />
-      <Tab icon="search" label="검색" active={sheet === "search"} badge={searchCount} aria-current={sheet === "search" ? "page" : undefined} aria-expanded={sheetsDisabled ? undefined : sheet === "search"} aria-controls={sheetsDisabled ? undefined : "sheet-search"} aria-disabled={sheetsDisabled || undefined} disabled={sheetsDisabled} onClick={() => { if (!sheetsDisabled) toggle("search"); }} />
-      <Tab icon="filter" label="필터" active={sheet === "filter"} badge={filterCount} aria-current={sheet === "filter" ? "page" : undefined} aria-expanded={sheetsDisabled ? undefined : sheet === "filter"} aria-controls={sheetsDisabled ? undefined : "sheet-filter"} aria-disabled={sheetsDisabled || undefined} disabled={sheetsDisabled} onClick={() => { if (!sheetsDisabled) toggle("filter"); }} />
+      <Tab icon="search" label="검색·필터" active={sheet === "search-filter"} badge={searchCount + filterCount} aria-current={sheet === "search-filter" ? "page" : undefined} aria-expanded={sheetsDisabled ? undefined : sheet === "search-filter"} aria-controls={sheetsDisabled ? undefined : "sheet-search-filter"} aria-disabled={sheetsDisabled || undefined} disabled={sheetsDisabled} onClick={() => { if (!sheetsDisabled) toggle("search-filter"); }} />
       <Tab icon="wishlist" label="찜목록" active={wishlistActive} aria-current={wishlistActive ? "page" : undefined} onClick={onWishlist} />
       <Tab icon="events" label="행사" active={sheet === "events" || context === "events"} aria-current={sheet === "events" || context === "events" ? "page" : undefined} aria-expanded={context === "settings" ? undefined : sheet === "events"} aria-controls={context === "settings" ? undefined : "sheet-events"} onClick={() => { if (context === "settings") onEvents(); else if (context !== "events") toggle("events"); }} />
       <Tab icon="settings" label="설정" active={settingsActive} aria-current={settingsActive ? "page" : undefined} onClick={onSettings} />

--- a/src/screens/ChecklistScreen.tsx
+++ b/src/screens/ChecklistScreen.tsx
@@ -69,7 +69,7 @@ export function ChecklistScreen({
   useEffect(() => {
     if (!sheet) { opener.current?.focus(); opener.current = null; return; }
     opener.current = document.activeElement as HTMLElement | null;
-    if (sheet === "search") searchRef.current?.focus();
+    if (sheet === "search-filter") searchRef.current?.focus();
     // 시트가 네비보다 DOM 앞에 있어 Tab으로 못 들어간다 — 첫 항목으로 포커스 이동
     if (sheet === "events") document.querySelector<HTMLElement>(`#sheet-${sheet} a, #sheet-${sheet} button`)?.focus();
     document.body.style.overflow = "hidden";
@@ -142,7 +142,7 @@ export function ChecklistScreen({
 
           {visibleSheet ? <button type="button" aria-label="시트 닫기" onClick={() => setSheet(null)} className="fixed inset-0 z-20 bg-black/40 md:hidden" /> : null}
 
-          <div id="sheet-search" role="group" aria-label="검색" className={sheetCls("search")}>
+          <div id="sheet-search-filter" role="group" aria-label="검색과 필터" className={sheetCls("search-filter")}>
             <div className="flex items-center gap-2.5 h-11 bg-card border border-line rounded-[14px] px-3.5 md:h-10 md:max-w-[520px]">
               <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="#9aa0aa" strokeWidth="2" strokeLinecap="round">
                 <circle cx="11" cy="11" r="7" />
@@ -174,7 +174,7 @@ export function ChecklistScreen({
             </div>
           </div>
 
-          <div id="sheet-filter" role="group" aria-label="필터" className={sheetCls("filter")}>
+          <div className="mt-3 md:mt-4" role="group" aria-label="필터">
             <div className="flex gap-2 md:mt-3.5">
               {STATUS.map((s) => (
                 <button key={s.k} onClick={() => setStatus(s.k)} aria-pressed={status === s.k} className={statusChip(status === s.k)}>

--- a/test/client/App.test.tsx
+++ b/test/client/App.test.tsx
@@ -511,7 +511,7 @@ describe("<App/> bottom navigation (mobile)", () => {
     render(<App />);
     await screen.findByText("부스서클");
     const nav = screen.getByRole("navigation", { name: "하단 메뉴" });
-    expect(nav.querySelectorAll("button").length).toBe(6);
+    expect(nav.querySelectorAll("button").length).toBe(5);
     expect(screen.getByRole("button", { name: "목록" }).getAttribute("aria-current")).toBe("page");
     const indicator = nav.querySelector<HTMLElement>('span[aria-hidden="true"]')!;
     expect(indicator.style.transform).toBe("translateX(0%)");

--- a/test/client/App.test.tsx
+++ b/test/client/App.test.tsx
@@ -515,7 +515,7 @@ describe("<App/> bottom navigation (mobile)", () => {
     expect(screen.getByRole("button", { name: "목록" }).getAttribute("aria-current")).toBe("page");
     const indicator = nav.querySelector<HTMLElement>('span[aria-hidden="true"]')!;
     expect(indicator.style.transform).toBe("translateX(0%)");
-    fireEvent.click(screen.getByRole("button", { name: "검색" }));
+    fireEvent.click(screen.getByRole("button", { name: "검색·필터" }));
     expect(indicator.style.transform).toBe("translateX(100%)");
 
     const eventsTab = screen.getByRole("button", { name: "행사" });
@@ -593,14 +593,14 @@ describe("<App/> bottom navigation (mobile)", () => {
     expect(within(screen.getByRole("complementary")).getByRole("link", { name: "설정" }).parentElement?.classList.contains("hidden")).toBe(true);
     const nav = screen.getByRole("navigation", { name: "하단 메뉴" });
     expect(screen.getByRole("button", { name: "행사" }).getAttribute("aria-current")).toBe("page");
-    const unavailable = [screen.getByRole("button", { name: "목록" }), screen.getByRole("button", { name: "검색" }), screen.getByRole("button", { name: "필터" })];
+    const unavailable = [screen.getByRole("button", { name: "목록" }), screen.getByRole("button", { name: "검색·필터" })];
     for (const tab of unavailable) {
       expect((tab as HTMLButtonElement).disabled).toBe(true);
       expect(tab.getAttribute("aria-disabled")).toBe("true");
       expect(tab.className).toContain("cursor-not-allowed");
       expect(tab.className).toContain("opacity");
     }
-    expect(nav.querySelectorAll('button[aria-disabled="true"]').length).toBe(3);
+    expect(nav.querySelectorAll('button[aria-disabled="true"]').length).toBe(2);
   });
 
   it("clears the selected 행사 when opening the landing from a checklist", async () => {
@@ -628,13 +628,12 @@ describe("<App/> bottom navigation (mobile)", () => {
     fireEvent.click(screen.getByRole("button", { name: "목록" }));
     expect(await screen.findByText("부스서클")).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "설정" }));
-    fireEvent.click(screen.getByRole("button", { name: "검색" }));
+    fireEvent.click(screen.getByRole("button", { name: "검색·필터" }));
     expect(await screen.findByRole("searchbox")).toBeTruthy();
     expect(window.location.hash).toBe("#/events/ev");
-    // 시트가 실제로 열린 상태여야 한다(hashchange 재진입으로 닫히면 안 됨)
     await act(async () => { fireEvent(window, new Event("hashchange")); });
-    expect(document.getElementById("sheet-search")!.classList.contains("hidden")).toBe(false);
-    expect(screen.getByRole("button", { name: "검색" }).getAttribute("aria-expanded")).toBe("true");
+    expect(document.getElementById("sheet-search-filter")!.classList.contains("hidden")).toBe(false);
+    expect(screen.getByRole("button", { name: "검색·필터" }).getAttribute("aria-expanded")).toBe("true");
   });
 
   it("keeps the bottom nav focused across screen changes", async () => {
@@ -656,36 +655,33 @@ describe("<App/> bottom navigation (mobile)", () => {
   it("toggles the search/filter sheets and shows the active filter count", async () => {
     render(<App />);
     await screen.findByText("부스서클");
-    const search = screen.getByRole("button", { name: "검색" });
-    expect(document.getElementById("sheet-search")!.classList.contains("hidden")).toBe(true);
-    search.focus(); // 실제 브라우저에서는 탭 클릭이 포커스를 옮긴다 — 시트 닫힘 후 포커스 복원 검증용
+    const search = screen.getByRole("button", { name: "검색·필터" });
+    expect(document.getElementById("sheet-search-filter")!.classList.contains("hidden")).toBe(true);
+    search.focus();
     fireEvent.click(search);
     expect(search.getAttribute("aria-expanded")).toBe("true");
     expect(search.getAttribute("aria-current")).toBe("page");
-    expect(document.getElementById("sheet-search")!.classList.contains("hidden")).toBe(false);
+    expect(document.getElementById("sheet-search-filter")!.classList.contains("hidden")).toBe(false);
     expect(document.activeElement).toBe(screen.getByRole("searchbox"));
     fireEvent.change(screen.getByRole("searchbox"), { target: { value: "부스" } });
-    expect(screen.getByRole("button", { name: "검색 1개 적용" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "검색·필터 1개 적용" })).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "시트 닫기" }));
-    expect(document.getElementById("sheet-search")!.classList.contains("hidden")).toBe(true);
-    expect(document.activeElement).toBe(screen.getByRole("button", { name: "검색 1개 적용" }));
+    expect(document.getElementById("sheet-search-filter")!.classList.contains("hidden")).toBe(true);
+    expect(document.activeElement).toBe(screen.getByRole("button", { name: "검색·필터 1개 적용" }));
     fireEvent.change(screen.getByRole("searchbox"), { target: { value: "" } });
 
-    fireEvent.click(screen.getByRole("button", { name: "필터" }));
-    expect(search.getAttribute("aria-expanded")).toBe("false");
-    expect(search.getAttribute("aria-current")).toBeNull();
-    expect(screen.getByRole("button", { name: "필터" }).getAttribute("aria-expanded")).toBe("true");
-    expect(screen.getByRole("button", { name: "필터" }).getAttribute("aria-current")).toBe("page");
+    fireEvent.click(search);
+    expect(search.getAttribute("aria-expanded")).toBe("true");
     fireEvent.click(screen.getByRole("button", { name: "체크함" }));
     fireEvent.click(screen.getByRole("button", { name: "걸즈밴드크라이" }));
-    expect(screen.getByRole("button", { name: "필터 2개 적용" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "검색·필터 2개 적용" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "목록" }).getAttribute("aria-current")).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "목록" }));
     expect(screen.getByRole("button", { name: "목록" }).getAttribute("aria-current")).toBe("page");
-    fireEvent.click(screen.getByRole("button", { name: "필터 2개 적용" }));
+    fireEvent.click(screen.getByRole("button", { name: "검색·필터 2개 적용" }));
 
     fireEvent.keyDown(window, { key: "Escape" });
-    expect(screen.getByRole("button", { name: "필터 2개 적용" }).getAttribute("aria-expanded")).toBe("false");
+    expect(screen.getByRole("button", { name: "검색·필터 2개 적용" }).getAttribute("aria-expanded")).toBe("false");
     expect(screen.queryByRole("button", { name: "시트 닫기" })).toBeNull();
   });
 
@@ -699,12 +695,12 @@ describe("<App/> bottom navigation (mobile)", () => {
   it("does not carry an open sheet into circle detail", async () => {
     render(<App />);
     await screen.findByText("부스서클");
-    fireEvent.click(screen.getByRole("button", { name: "검색" }));
-    expect(screen.getByRole("group", { name: "검색" }).classList.contains("hidden")).toBe(false);
+    fireEvent.click(screen.getByRole("button", { name: "검색·필터" }));
+    expect(screen.getByRole("group", { name: "검색과 필터" }).classList.contains("hidden")).toBe(false);
 
     fireEvent.click(screen.getByText("부스서클"));
     expect(await screen.findByText("서클 상세")).toBeTruthy();
     expect(screen.queryByRole("button", { name: "시트 닫기" })).toBeNull();
-    expect(screen.getByRole("group", { name: "검색" }).classList.contains("hidden")).toBe(true);
+    expect(screen.getByRole("group", { name: "검색과 필터" }).classList.contains("hidden")).toBe(true);
   });
 });


### PR DESCRIPTION
## 변경 사항\n- 모바일 하단 내비게이션의 검색·필터를 하나의 메뉴로 통합\n- 통합 메뉴에서 검색과 상태·장르 필터를 함께 조작\n- 적용된 검색어·필터 개수와 접근성 상태를 통합 표시\n\nCloses #77\n\n## 검증\n- npx tsc -p tsconfig.json --noEmit\n- npx tsc -p worker/tsconfig.json --noEmit\n- npm test는 현재 Node.js 버전의 NODE_OPTIONS/ESM 호환 문제로 실행 불가\n- npm run build는 현재 Node.js 버전이 @cloudflare/vite-plugin의 registerHooks를 지원하지 않아 실행 불가