### PR TITLE
fix: 모바일 하단 내비게이션 활성 상태 및 가독성 개선

### DIFF
--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -88,7 +88,7 @@ export function BottomNav({
       const y = navRect.top + navRect.height / 2;
       const previousPointerEvents = nav.style.pointerEvents;
       nav.style.pointerEvents = "none";
-      const underlying = document.elementFromPoint(x, y);
+      const underlying = typeof document.elementFromPoint === "function" ? document.elementFromPoint(x, y) : null;
       nav.style.pointerEvents = previousPointerEvents;
       setContentOverlaps(underlying instanceof HTMLElement && content.contains(underlying));
     };

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from "react";
+
 export type Sheet = "search-filter" | "events" | null;
 
 const ICONS = {
@@ -69,17 +71,47 @@ export function BottomNav({
 }) {
   const settingsActive = context === "settings";
   const toggle = (s: Exclude<Sheet, null>) => onSheet(sheet === s ? null : s);
-  const activeIndex = settingsActive ? 5 : wishlistActive ? 3 : context === "events" ? 4 : sheet === "search-filter" ? 1 : sheet === "events" ? 4 : 0;
+  const tabsCount = 5;
+  const activeIndex = settingsActive ? 4 : wishlistActive ? 2 : context === "events" ? 3 : sheet === "search-filter" ? 1 : sheet === "events" ? 3 : 0;
+  const [contentOverlaps, setContentOverlaps] = useState(false);
   const listActive = activeIndex === 0;
   const sheetsDisabled = context === "events";
   const listDisabled = context === "events";
+
+  useEffect(() => {
+    const nav = document.querySelector<HTMLElement>('nav[aria-label="하단 메뉴"]');
+    const content = document.querySelector<HTMLElement>("main");
+    if (!nav || !content) return;
+    const updateOverlap = () => {
+      const navRect = nav.getBoundingClientRect();
+      const x = navRect.left + navRect.width / 2;
+      const y = navRect.top + navRect.height / 2;
+      const previousPointerEvents = nav.style.pointerEvents;
+      nav.style.pointerEvents = "none";
+      const underlying = document.elementFromPoint(x, y);
+      nav.style.pointerEvents = previousPointerEvents;
+      setContentOverlaps(underlying instanceof HTMLElement && content.contains(underlying));
+    };
+    const resizeObserver = typeof ResizeObserver === "undefined" ? null : new ResizeObserver(updateOverlap);
+    resizeObserver?.observe(nav);
+    resizeObserver?.observe(content);
+    updateOverlap();
+    window.addEventListener("resize", updateOverlap);
+    window.addEventListener("scroll", updateOverlap, { passive: true });
+    return () => {
+      resizeObserver?.disconnect();
+      window.removeEventListener("resize", updateOverlap);
+      window.removeEventListener("scroll", updateOverlap);
+    };
+  }, [context, sheet]);
+
   return (
-    <nav aria-label="하단 메뉴" className="glass glass-refract fixed left-1/2 -translate-x-1/2 w-[calc(100%-24px)] max-w-[536px] bottom-[calc(env(safe-area-inset-bottom)+12px)] z-30 flex rounded-full p-1.5 md:hidden">
+    <nav aria-label="하단 메뉴" data-content-overlap={contentOverlaps ? "true" : "false"} className="glass glass-refract fixed left-1/2 -translate-x-1/2 w-[calc(100%-24px)] max-w-[536px] bottom-[calc(env(safe-area-inset-bottom)+12px)] z-30 flex rounded-full p-1.5 md:hidden">
       {/* 렌즈 인디케이터 — 탭 사이를 액체처럼 미끄러진다. */}
       <span
         aria-hidden="true"
-        className="glass-lens absolute inset-y-1.5 left-1.5 w-[calc(16.6667%-2.5px)]"
-        style={{ transform: `translateX(${activeIndex * 100}%)` }}
+        className="glass-lens absolute inset-y-1.5 left-1.5"
+        style={{ transform: `translateX(${activeIndex * 100}%)`, width: `calc(${100 / tabsCount}% - 2.5px)` }}
       >
         <span key={activeIndex} className="glass-lens-body block h-full w-full rounded-full" />
       </span>

--- a/src/index.css
+++ b/src/index.css
@@ -141,7 +141,15 @@ body {
   @supports (backdrop-filter: url(#lg-refract)) {
     backdrop-filter: blur(2px) url(#lg-refract) saturate(170%) brightness(1.08);
   }
+  &[data-content-overlap="true"] {
+    background: color-mix(in srgb, var(--glass-bg) 82%, var(--app-panel));
+    -webkit-backdrop-filter: blur(18px) saturate(170%) brightness(1.08);
+    backdrop-filter: blur(18px) saturate(170%) brightness(1.08);
+    box-shadow: 0 8px 32px rgba(0, 0, 0, .28), inset 0 1px 1px var(--glass-rim);
+  }
   @media (prefers-reduced-transparency: reduce) {
+    background: var(--app-panel);
+    -webkit-backdrop-filter: none;
     backdrop-filter: none;
   }
 }

--- a/src/screens/EventsScreen.tsx
+++ b/src/screens/EventsScreen.tsx
@@ -12,7 +12,7 @@ export function EventsScreen({ install, onOpenSettings, wishlist = [], onToggleW
     .sort((a, b) => (a.start_date ?? "").localeCompare(b.start_date ?? ""));
 
   return (
-    <div className="px-5 pt-7 pb-2 md:px-8 md:py-10">
+    <div className="px-5 pt-7 pb-[calc(88px+env(safe-area-inset-bottom))] md:px-8 md:py-10">
       <h1 className="text-[26px] font-extrabold text-ink">행사 선택</h1>
       <p className="mt-2 text-sm text-muted">방문할 행사를 골라 관심 서클을 확인하세요.</p>
       <InstallBanner install={install} onOpenSettings={onOpenSettings} />

--- a/test/client/App.test.tsx
+++ b/test/client/App.test.tsx
@@ -507,7 +507,7 @@ describe("<App/> bottom navigation (mobile)", () => {
     vi.unstubAllGlobals();
   });
 
-  it("renders 6 tabs and opens the 행사 sheet without hiding the nav", async () => {
+  it("renders 5 tabs and opens the 행사 sheet without hiding the nav", async () => {
     render(<App />);
     await screen.findByText("부스서클");
     const nav = screen.getByRole("navigation", { name: "하단 메뉴" });
@@ -520,7 +520,7 @@ describe("<App/> bottom navigation (mobile)", () => {
 
     const eventsTab = screen.getByRole("button", { name: "행사" });
     fireEvent.click(eventsTab);
-    expect(indicator.style.transform).toBe("translateX(400%)");
+    expect(indicator.style.transform).toBe("translateX(300%)");
     expect(eventsTab.getAttribute("aria-expanded")).toBe("true");
     expect(eventsTab.getAttribute("aria-controls")).toBe("sheet-events");
     const sheet = document.getElementById("sheet-events")!;
@@ -593,6 +593,7 @@ describe("<App/> bottom navigation (mobile)", () => {
     expect(within(screen.getByRole("complementary")).getByRole("link", { name: "설정" }).parentElement?.classList.contains("hidden")).toBe(true);
     const nav = screen.getByRole("navigation", { name: "하단 메뉴" });
     expect(screen.getByRole("button", { name: "행사" }).getAttribute("aria-current")).toBe("page");
+    expect(nav.querySelector<HTMLElement>('span[aria-hidden="true"]')!.style.transform).toBe("translateX(300%)");
     const unavailable = [screen.getByRole("button", { name: "목록" }), screen.getByRole("button", { name: "검색·필터" })];
     for (const tab of unavailable) {
       expect((tab as HTMLButtonElement).disabled).toBe(true);
@@ -611,6 +612,32 @@ describe("<App/> bottom navigation (mobile)", () => {
     fireEvent.click(screen.getByRole("button", { name: "행사" }));
     await screen.findByRole("heading", { name: "행사 선택" });
     expect(screen.getByRole("link", { name: /코믹월드/ }).getAttribute("aria-current")).toBeNull();
+  });
+
+  it("strengthens the nav background when content is underneath", async () => {
+    const elementFromPoint = vi.spyOn(document, "elementFromPoint").mockReturnValue(null);
+    render(<App />);
+    await screen.findByText("부스서클");
+    const nav = screen.getByRole("navigation", { name: "하단 메뉴" });
+    expect(nav.dataset.contentOverlap).toBe("false");
+
+    elementFromPoint.mockReturnValue(screen.getByText("부스서클"));
+    fireEvent(window, new Event("resize"));
+    expect(nav.dataset.contentOverlap).toBe("true");
+  });
+
+  it("marks wishlist and settings as the active tab position", async () => {
+    window.location.hash = "#/wishlist";
+    render(<App />);
+    expect(await screen.findByRole("heading", { name: "찜목록" })).toBeTruthy();
+    const nav = screen.getByRole("navigation", { name: "하단 메뉴" });
+    expect(nav.querySelector<HTMLElement>('span[aria-hidden="true"]')!.style.transform).toBe("translateX(200%)");
+    expect(screen.getByRole("button", { name: "찜목록" }).getAttribute("aria-current")).toBe("page");
+
+    fireEvent.click(screen.getByRole("button", { name: "설정" }));
+    expect(await screen.findByRole("heading", { name: "설정" })).toBeTruthy();
+    expect(nav.querySelector<HTMLElement>('span[aria-hidden="true"]')!.style.transform).toBe("translateX(400%)");
+    expect(screen.getByRole("button", { name: "설정" }).getAttribute("aria-current")).toBe("page");
   });
 
   it("connects settings navigation to the current checklist", async () => {

--- a/test/client/App.test.tsx
+++ b/test/client/App.test.tsx
@@ -615,7 +615,8 @@ describe("<App/> bottom navigation (mobile)", () => {
   });
 
   it("strengthens the nav background when content is underneath", async () => {
-    const elementFromPoint = vi.spyOn(document, "elementFromPoint").mockReturnValue(null);
+    const elementFromPoint = vi.fn().mockReturnValue(null);
+    Object.defineProperty(document, "elementFromPoint", { configurable: true, value: elementFromPoint });
     render(<App />);
     await screen.findByText("부스서클");
     const nav = screen.getByRole("navigation", { name: "하단 메뉴" });


### PR DESCRIPTION
## 변경 사항\n- 5개 모바일 탭 기준 active 인디케이터 위치 보정\n- 행사 선택 화면 하단 내비게이션 겹침 방지 여백 추가\n- 콘텐츠 겹침 감지 시 글래스 배경 강화\n- reduced-transparency 및 라우팅/active 상태 테스트 보강\n\n## 검증\n- npm run typecheck 통과\n- npm test / npm run build는 현재 Node.js v18 환경 호환성 문제로 실행 불가\n\nCloses #79